### PR TITLE
feat: include version in /health response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [0.1.1] - 2026-03-05
+
+### Changed
+- `/health` endpoint now returns `{"status": "ok", "version": "<version>"}` for easier debugging and monitoring
+- Version sourced from `agent0.__version__` (set at module load time, not per-request)
+- `FastAPI` app version metadata now also driven from `__version__` instead of a hardcoded string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent0"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.12"
 dependencies = [
     "httpx==0.28.1",

--- a/src/agent0/__init__.py
+++ b/src/agent0/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 __all__ = ['__version__']

--- a/src/agent0/api.py
+++ b/src/agent0/api.py
@@ -5,6 +5,7 @@ from typing import Any, Protocol
 from fastapi import FastAPI, Query
 from fastapi.staticfiles import StaticFiles
 
+from agent0 import __version__
 from agent0.audit import read_entry_output, read_history
 from agent0.config import Config
 from agent0.logbuffer import LogBuffer
@@ -51,11 +52,11 @@ def create_app(
         FastAPI: Configured FastAPI application
     '''
 
-    app = FastAPI(title='Agent0', version='0.1.0')
+    app = FastAPI(title='Agent0', version=__version__)
 
     @app.get('/health')
     async def health() -> dict[str, str]:
-        return {'status': 'ok'}
+        return {'status': 'ok', 'version': __version__}
 
     @app.get('/api/tasks/running')
     async def running_tasks() -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary

- `/health` now returns `{"status": "ok", "version": "0.1.1"}` instead of just `{"status": "ok"}`
- Version is sourced from `agent0.__version__` (imported at module load time — zero per-request overhead)
- Same constant now drives the FastAPI OpenAPI metadata version (was a hardcoded `'0.1.0'` literal)
- Bumped package version to `0.1.1` in `pyproject.toml` and `__init__.py`
- Added `CHANGELOG.md`

Closes #9

## Test plan

- [ ] `GET /health` returns `{"status": "ok", "version": "0.1.1"}`
- [ ] Existing tests still pass (`pytest`)
- [ ] Version in `/docs` (OpenAPI) matches `__version__`

🤖 Generated with [Claude Code](https://claude.com/claude-code)