### PR TITLE
Validate whitelisted_orgs is non-empty at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.2] - 2026-03-05
+
+### Changed
+- `load_config` now raises `ValueError` at startup if `WHITELISTED_ORGS` resolves to an empty list, providing a clear error message instead of silently operating with no allowed organizations
+
 ## [0.1.1] - 2026-03-05
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent0"
-version = "0.1.1"
+version = "0.1.2"
 requires-python = ">=3.12"
 dependencies = [
     "httpx==0.28.1",

--- a/src/agent0/config.py
+++ b/src/agent0/config.py
@@ -120,6 +120,12 @@ def load_config() -> Config:
     else:
         whitelisted_orgs = ('vaquum',)
 
+    if not whitelisted_orgs:
+        raise ValueError(
+            'WHITELISTED_ORGS must contain at least one organization. '
+            'Set it to a comma-separated list of GitHub org names (e.g. WHITELISTED_ORGS=vaquum).'
+        )
+
     poll_interval = int(os.environ.get('POLL_INTERVAL', '30'))
     executor_timeout = int(os.environ.get('EXECUTOR_TIMEOUT', '1800'))
     max_turns = int(os.environ.get('MAX_TURNS', '100'))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,6 +99,22 @@ class TestLoadConfig:
         config = load_config()
         assert config.whitelisted_orgs == ('org1', 'org2', 'org3')
 
+    def test_empty_whitelisted_orgs_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+
+        '''
+        Compute that an empty WHITELISTED_ORGS raises ValueError.
+
+        Returns:
+            None
+        '''
+
+        monkeypatch.setenv('GITHUB_TOKEN', 'ghp_test')
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'sk-ant-test')
+        monkeypatch.setenv('WHITELISTED_ORGS', ' , , ')
+
+        with pytest.raises(ValueError, match='WHITELISTED_ORGS must contain at least one organization'):
+            load_config()
+
 
 class TestConfig:
 


### PR DESCRIPTION
## Summary
- `load_config` now raises `ValueError` if `WHITELISTED_ORGS` resolves to an empty list (e.g. set to blank or a comma-only string)
- Error message clearly tells the operator what to fix: `WHITELISTED_ORGS must contain at least one organization. Set it to a comma-separated list of GitHub org names (e.g. WHITELISTED_ORGS=vaquum).`
- Added a test (`test_empty_whitelisted_orgs_raises`) to cover this case

Closes #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)