### PR TITLE
Fix test assertion for updated preamble

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -72,7 +72,7 @@ class TestBuildPrompt:
         ctx = _make_context()
         prompt = _build_prompt(ctx, config)
 
-        assert 'You are zero-bang' in prompt
+        assert 'You are Agent0' in prompt
         assert 'testorg/myrepo' in prompt
         assert 'Never force push' in prompt
 


### PR DESCRIPTION
## Summary
- Update `test_preamble_present` to check for `"You are Agent0"` instead of `"You are zero-bang"`, matching the user's manual edit to `prompts.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)