### PR TITLE
fix(prompts): rewrite RE_REVIEW_PR to match agreed re-review behavior

### DIFF
--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -205,7 +205,7 @@ Conversation:
 - Submit exactly ONE review action. Do not run `gh pr review` more than once.
 - When approving, run `gh pr review {number} --approve` with no other flags. No --body. No comment.
 - Do not use `gh pr comment` or `gh issue comment`.
-- Do not write any summary, commentary, or praise."""
+- Do not write any additional summary, commentary, or praise beyond the exact --body text specified in step 5 for changes-requested reviews."""
 
 
 CI_FAILURE = """CI checks have failed on your PR #{number}: "{title}"

--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -186,10 +186,11 @@ Conversation:
    gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login=="{github_user}") | {{id: .id, path: .path, line: .line, body: .body}}'
    ```
 2. For each of your previous comments, check whether the issue was fixed in the current diff.
-3. If ALL your previous comments are resolved (without any additional comments):
+3. If ALL your previous comments are resolved, approve:
    ```bash
    gh pr review {number} --approve
    ```
+   This command must be run exactly as shown. Do not add --body or any other flags.
 4. If some issues remain, reply to those specific threads explaining what is still wrong:
    ```bash
    gh api repos/{owner}/{repo}/pulls/{number}/comments/COMMENT_ID/replies --method POST -f body="This is still not addressed: ..."
@@ -197,7 +198,14 @@ Conversation:
 5. After replying to unresolved threads, submit a changes-requested review:
    ```bash
    gh pr review {number} --request-changes --body "Some items from my previous review still need to be addressed. See my replies on the relevant threads."
-   ```"""
+   ```
+
+## Rules
+
+- Submit exactly ONE review action. Do not run `gh pr review` more than once.
+- When approving, run `gh pr review {number} --approve` with no other flags. No --body. No comment.
+- Do not use `gh pr comment` or `gh issue comment`.
+- Do not write any summary, commentary, or praise."""
 
 
 CI_FAILURE = """CI checks have failed on your PR #{number}: "{title}"

--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -202,7 +202,8 @@ Conversation:
 
 ## Rules
 
-- Submit exactly ONE review action. Do not run `gh pr review` more than once.
+- Run `gh pr review` exactly once per execution. Do not run `gh pr review` more than once.
+- You may call `gh api` to reply to multiple unresolved threads before that single `gh pr review` command.
 - When approving, run `gh pr review {number} --approve` with no other flags. No --body. No comment.
 - Do not use `gh pr comment` or `gh issue comment`.
 - Do not write any additional summary, commentary, or praise beyond the exact --body text specified in step 5 for changes-requested reviews."""

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -228,7 +228,7 @@ class TestBuildPrompt:
         prompt = _build_prompt(ctx, config)
 
         assert 're-review' in prompt.lower()
-        assert 'without any additional comments' in prompt
+        assert 'Submit exactly ONE review action' in prompt
         assert 'gh pr review' in prompt
 
     def test_review_request_has_no_rereview_logic(self) -> None:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -230,6 +230,7 @@ class TestBuildPrompt:
         assert 're-review' in prompt.lower()
         assert 'Submit exactly ONE review action' in prompt
         assert 'gh pr review' in prompt
+        assert 'do not add --body' in prompt.lower()
 
     def test_review_request_has_no_rereview_logic(self) -> None:
         """

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -228,7 +228,7 @@ class TestBuildPrompt:
         prompt = _build_prompt(ctx, config)
 
         assert 're-review' in prompt.lower()
-        assert 'Submit exactly ONE review action' in prompt
+        assert 'gh pr review` exactly once per execution' in prompt
         assert 'gh pr review' in prompt
         assert 'do not add --body' in prompt.lower()
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -65,7 +65,7 @@ class TestPromptsModule:
         assert '{github_user}' in prompts.RE_REVIEW_PR
         assert 'gh pr review {number} --approve' in prompts.RE_REVIEW_PR
         assert 'Do not add --body' in prompts.RE_REVIEW_PR
-        assert 'Submit exactly ONE review action' in prompts.RE_REVIEW_PR
+        assert 'gh pr review` exactly once per execution' in prompts.RE_REVIEW_PR
 
     def test_review_pr_has_no_rereview_logic(self) -> None:
         """

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -64,7 +64,7 @@ class TestPromptsModule:
         assert '{owner}' in prompts.RE_REVIEW_PR
         assert '{github_user}' in prompts.RE_REVIEW_PR
         assert 'gh pr review {number} --approve' in prompts.RE_REVIEW_PR
-        assert 'without any additional comments' in prompts.RE_REVIEW_PR
+        assert 'Submit exactly ONE review action' in prompts.RE_REVIEW_PR
 
     def test_review_pr_has_no_rereview_logic(self) -> None:
         """

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -64,6 +64,7 @@ class TestPromptsModule:
         assert '{owner}' in prompts.RE_REVIEW_PR
         assert '{github_user}' in prompts.RE_REVIEW_PR
         assert 'gh pr review {number} --approve' in prompts.RE_REVIEW_PR
+        assert 'Do not add --body' in prompts.RE_REVIEW_PR
         assert 'Submit exactly ONE review action' in prompts.RE_REVIEW_PR
 
     def test_review_pr_has_no_rereview_logic(self) -> None:


### PR DESCRIPTION
## Summary

- Adds explicit rules to RE_REVIEW_PR prompt: no `--body` on approve, exactly one review action per session, no commentary or praise
- Updates test assertions to match new prompt content

Observed on Limen PR #412: Claude submitted duplicate approvals (3 seconds apart) with body text despite the template showing bare `--approve`. Root cause: prompt lacked explicit constraints.

## Test plan

- [x] 224 tests pass
- [x] ruff check clean
- [x] ruff format clean
- [ ] Verify next re-review produces silent approve (no body text)
- [ ] Verify no duplicate reviews on next re-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)