### PR TITLE
feat(executor): pin Claude Code CLI to claude-opus-4-6

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ ANTHROPIC_API_KEY=
 # GitHub username that Agent0 operates as (production)
 GITHUB_USER=
 
+# Claude model identifier passed to Claude Code CLI --model flag
+CLAUDE_MODEL=
+
 # Comma-separated list of GitHub organizations Agent0 is allowed to act on
 WHITELISTED_ORGS=
 

--- a/docs/Developer/Executor.md
+++ b/docs/Developer/Executor.md
@@ -13,7 +13,7 @@ The executor is the bridge between Agent0's notification pipeline and Claude Cod
 The executor invokes the Claude Code CLI with these flags:
 
 ```
-claude --print --verbose --output-format stream-json --dangerously-skip-permissions --max-turns N
+claude --print --verbose --output-format stream-json --dangerously-skip-permissions --model claude-opus-4-6 --max-turns N
 ```
 
 | Flag | Purpose |
@@ -22,6 +22,7 @@ claude --print --verbose --output-format stream-json --dangerously-skip-permissi
 | `--verbose` | Includes token counts, cost, and turn metadata in output |
 | `--output-format stream-json` | One JSON object per line, streaming as the agent works |
 | `--dangerously-skip-permissions` | Skips tool permission prompts (required for unattended execution) |
+| `--model claude-opus-4-6` | Pins the model to Claude Opus 4.6 |
 | `--max-turns N` | Limits agentic turns to prevent runaway sessions |
 
 The prompt is piped through stdin. Three environment variables are set:

--- a/docs/Developer/Executor.md
+++ b/docs/Developer/Executor.md
@@ -13,7 +13,7 @@ The executor is the bridge between Agent0's notification pipeline and Claude Cod
 The executor invokes the Claude Code CLI with these flags:
 
 ```
-claude --print --verbose --output-format stream-json --dangerously-skip-permissions --model claude-opus-4-6 --max-turns N
+claude --print --verbose --output-format stream-json --dangerously-skip-permissions --model <CLAUDE_MODEL> --max-turns N
 ```
 
 | Flag | Purpose |
@@ -22,7 +22,7 @@ claude --print --verbose --output-format stream-json --dangerously-skip-permissi
 | `--verbose` | Includes token counts, cost, and turn metadata in output |
 | `--output-format stream-json` | One JSON object per line, streaming as the agent works |
 | `--dangerously-skip-permissions` | Skips tool permission prompts (required for unattended execution) |
-| `--model claude-opus-4-6` | Pins the model to Claude Opus 4.6 |
+| `--model <CLAUDE_MODEL>` | Model identifier from `CLAUDE_MODEL` env var |
 | `--max-turns N` | Limits agentic turns to prevent runaway sessions |
 
 The prompt is piped through stdin. Three environment variables are set:

--- a/render.yaml
+++ b/render.yaml
@@ -16,6 +16,8 @@ services:
         sync: false
       - key: ANTHROPIC_API_KEY
         sync: false
+      - key: CLAUDE_MODEL
+        sync: false
       - key: WHITELISTED_ORGS
         sync: false
       - key: POLL_INTERVAL

--- a/src/agent0/config.py
+++ b/src/agent0/config.py
@@ -18,6 +18,7 @@ class Config:
         github_token (str): PAT for Agent0 with repo and notifications scopes
         anthropic_api_key (str): API key for Claude Code
         github_user (str): GitHub username for the agent
+        claude_model (str): Model identifier for Claude Code CLI --model flag
         whitelisted_orgs (tuple[str, ...]): Organizations to respond to
         agent0_repo (str): Repository name for Agent0 itself (e.g. 'Agent0')
         poll_interval (int): Seconds between notification polls
@@ -34,6 +35,7 @@ class Config:
     github_token: str
     anthropic_api_key: str
     github_user: str
+    claude_model: str
     whitelisted_orgs: tuple[str, ...]
     agent0_repo: str = 'Agent0'
     poll_interval: int = 30
@@ -81,6 +83,7 @@ class Config:
         return (
             f'github_token={_mask(self.github_token)} '
             f'anthropic_api_key={_mask(self.anthropic_api_key)} '
+            f'claude_model={self.claude_model} '
             f'poll_interval={self.poll_interval} '
             f'whitelisted_orgs={",".join(self.whitelisted_orgs)} '
             f'agent0_repo={self.agent0_repo} '
@@ -137,6 +140,11 @@ def load_config() -> Config:
         log.error('E1001: GITHUB_USER environment variable is required')
         sys.exit(1)
 
+    claude_model = os.environ.get('CLAUDE_MODEL', '')
+    if not claude_model:
+        log.error('E1001: CLAUDE_MODEL environment variable is required')
+        sys.exit(1)
+
     orgs_raw = os.environ.get('WHITELISTED_ORGS', '')
     whitelisted_orgs = tuple(org.strip() for org in orgs_raw.split(',') if org.strip())
 
@@ -158,6 +166,7 @@ def load_config() -> Config:
         github_token=github_token,
         anthropic_api_key=anthropic_api_key,
         github_user=github_user,
+        claude_model=claude_model,
         whitelisted_orgs=whitelisted_orgs,
         agent0_repo=agent0_repo,
         poll_interval=poll_interval,

--- a/src/agent0/executor.py
+++ b/src/agent0/executor.py
@@ -336,6 +336,8 @@ async def run(
         '--output-format',
         'stream-json',
         '--dangerously-skip-permissions',
+        '--model',
+        'claude-opus-4-6',
         '--max-turns',
         str(config.max_turns),
     ]

--- a/src/agent0/executor.py
+++ b/src/agent0/executor.py
@@ -337,7 +337,7 @@ async def run(
         'stream-json',
         '--dangerously-skip-permissions',
         '--model',
-        'claude-opus-4-6',
+        config.claude_model,
         '--max-turns',
         str(config.max_turns),
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def make_config():
             'github_token': 'test-token',
             'anthropic_api_key': 'test-key',
             'github_user': 'zero-bang',
+            'claude_model': 'test-model',
             'whitelisted_orgs': ('Vaquum',),
         }
         if tmp_path is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ def _make_config(tmp_path: Path) -> Config:
         github_token='test-token',
         anthropic_api_key='test-key',
         github_user='zero-bang',
+        claude_model='test-model',
         whitelisted_orgs=('Vaquum',),
         data_dir=tmp_path,
     )

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -22,6 +22,7 @@ def _make_config(tmp_path: Path) -> Config:
         github_token='test',
         anthropic_api_key='test',
         github_user='test-bot',
+        claude_model='test-model',
         whitelisted_orgs=('testorg',),
         data_dir=tmp_path,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,6 +46,21 @@ class TestLoadConfig:
         with pytest.raises(SystemExit):
             load_config()
 
+    def test_missing_claude_model_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """
+        Compute that missing CLAUDE_MODEL causes SystemExit.
+
+        Returns:
+            None
+        """
+
+        monkeypatch.setenv('GITHUB_TOKEN', 'test-token')
+        monkeypatch.setenv('ANTHROPIC_API_KEY', 'test-key')
+        monkeypatch.setenv('GITHUB_USER', 'test-bot')
+        monkeypatch.delenv('CLAUDE_MODEL', raising=False)
+        with pytest.raises(SystemExit):
+            load_config()
+
     def test_defaults_applied(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """
         Compute that default values are applied correctly.
@@ -57,6 +72,7 @@ class TestLoadConfig:
         monkeypatch.setenv('GITHUB_TOKEN', 'ghp_test123')
         monkeypatch.setenv('ANTHROPIC_API_KEY', 'sk-ant-test123')
         monkeypatch.setenv('GITHUB_USER', 'my-bot')
+        monkeypatch.setenv('CLAUDE_MODEL', 'claude-opus-4-6')
         monkeypatch.setenv('WHITELISTED_ORGS', 'myorg')
         for key in ('POLL_INTERVAL', 'EXECUTOR_TIMEOUT', 'MAX_TURNS', 'LOG_LEVEL', 'DATA_DIR'):
             monkeypatch.delenv(key, raising=False)
@@ -81,6 +97,7 @@ class TestLoadConfig:
         monkeypatch.setenv('GITHUB_TOKEN', 'ghp_custom')
         monkeypatch.setenv('ANTHROPIC_API_KEY', 'sk-ant-custom')
         monkeypatch.setenv('GITHUB_USER', 'custom-bot')
+        monkeypatch.setenv('CLAUDE_MODEL', 'claude-opus-4-6')
         monkeypatch.setenv('POLL_INTERVAL', '60')
         monkeypatch.setenv('WHITELISTED_ORGS', 'orgA, orgB, orgC')
         monkeypatch.setenv('EXECUTOR_TIMEOUT', '300')
@@ -105,6 +122,7 @@ class TestLoadConfig:
         monkeypatch.setenv('GITHUB_TOKEN', 'ghp_test')
         monkeypatch.setenv('ANTHROPIC_API_KEY', 'sk-ant-test')
         monkeypatch.setenv('GITHUB_USER', 'test-bot')
+        monkeypatch.setenv('CLAUDE_MODEL', 'claude-opus-4-6')
         monkeypatch.setenv('WHITELISTED_ORGS', ' org1 , org2 , , org3 ')
 
         config = load_config()
@@ -121,6 +139,7 @@ class TestLoadConfig:
         monkeypatch.setenv('GITHUB_TOKEN', 'ghp_test')
         monkeypatch.setenv('ANTHROPIC_API_KEY', 'sk-ant-test')
         monkeypatch.setenv('GITHUB_USER', 'test-bot')
+        monkeypatch.setenv('CLAUDE_MODEL', 'claude-opus-4-6')
         monkeypatch.setenv('WHITELISTED_ORGS', ' , , ')
 
         with pytest.raises(
@@ -142,6 +161,7 @@ class TestConfig:
             github_token='test',
             anthropic_api_key='test',
             github_user='test-bot',
+            claude_model='test-model',
             whitelisted_orgs=('testorg',),
             data_dir=Path('/mydata'),
         )
@@ -159,6 +179,7 @@ class TestConfig:
             github_token='test',
             anthropic_api_key='test',
             github_user='test-bot',
+            claude_model='test-model',
             whitelisted_orgs=('testorg',),
             data_dir=Path('/mydata'),
         )
@@ -176,6 +197,7 @@ class TestConfig:
             github_token='ghp_abcdef123456789',
             anthropic_api_key='sk-ant-abcdef123456789',
             github_user='test-bot',
+            claude_model='test-model',
             whitelisted_orgs=('testorg',),
         )
         redacted = config.log_redacted()
@@ -196,6 +218,7 @@ class TestConfig:
             github_token='short',
             anthropic_api_key='tiny',
             github_user='test-bot',
+            claude_model='test-model',
             whitelisted_orgs=('testorg',),
         )
         redacted = config.log_redacted()
@@ -215,6 +238,7 @@ class TestConfig:
             github_token='test',
             anthropic_api_key='test',
             github_user='test-bot',
+            claude_model='test-model',
             whitelisted_orgs=('testorg',),
         )
         with pytest.raises(AttributeError):

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -16,6 +16,7 @@ def _make_config() -> Config:
         github_token='test',
         anthropic_api_key='test',
         github_user='test-bot',
+        claude_model='test-model',
         whitelisted_orgs=('testorg',),
     )
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -23,6 +23,7 @@ def _make_config() -> Config:
         github_token='test',
         anthropic_api_key='test',
         github_user='test-bot',
+        claude_model='test-model',
         whitelisted_orgs=('testorg',),
     )
 

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -26,6 +26,7 @@ def _make_config() -> Config:
         github_token='test-token',
         anthropic_api_key='test-key',
         github_user='test-bot',
+        claude_model='test-model',
         whitelisted_orgs=('testorg', 'otherorg'),
     )
 

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -24,6 +24,7 @@ def _make_config(tmp_path: Path) -> Config:
         github_token='test-token',
         anthropic_api_key='test-key',
         github_user='zero-bang',
+        claude_model='test-model',
         whitelisted_orgs=('vaquum',),
         data_dir=tmp_path,
     )
@@ -267,6 +268,7 @@ class TestScanMultipleOrgs:
             github_token='test-token',
             anthropic_api_key='test-key',
             github_user='zero-bang',
+            claude_model='test-model',
             whitelisted_orgs=('orgA', 'orgB'),
             data_dir=tmp_path,
         )

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -23,6 +23,7 @@ def _make_config() -> Config:
         github_token='test',
         anthropic_api_key='test',
         github_user='test-bot',
+        claude_model='test-model',
         whitelisted_orgs=('testorg',),
     )
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -23,6 +23,7 @@ def _make_config(tmp_path: Path) -> Config:
         github_token='ghp_test123',
         anthropic_api_key='test',
         github_user='test-bot',
+        claude_model='test-model',
         whitelisted_orgs=('testorg',),
         data_dir=tmp_path,
     )


### PR DESCRIPTION
## Summary

- Adds `--model claude-opus-4-6` to the Claude Code CLI invocation in executor.py
- Updates Executor developer docs with the new flag

Agent0 was using whatever default model Claude Code ships with. This pins it explicitly so a default change upstream can't silently switch models.

## Test plan

- [x] 224 tests pass
- [x] ruff check clean
- [x] ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)