### PR TITLE
feat(prompts): structured review protocol from 23 self-reflection RFCs

### DIFF
--- a/.github/workflows/pr-post-release.yml
+++ b/.github/workflows/pr-post-release.yml
@@ -1,0 +1,44 @@
+name: Automated Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  create_release:
+    name: Create Automated Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for git log analysis
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install GitHub CLI
+        run: |
+          # GitHub CLI should already be installed in ubuntu-latest
+          gh --version
+
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create release with Claude
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Install Anthropic SDK
+          pip install anthropic
+
+          # Create the release automation script
+          python scripts/create_release.py

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Automated release creation script using Claude AI."""
+# ruff: noqa: T201, S607, S603, BLE001
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+import anthropic
+
+
+DEFAULT_RELEASE_DOCS_URL = (
+    'https://raw.githubusercontent.com/'
+    'Vaquum/dev-docs/551e77b251dc3e70548b8bcd645d702c8f80e3b6/src/Making-Release.md'
+)
+RELEASE_DOCS_URL = os.getenv('RELEASE_DOCS_URL', DEFAULT_RELEASE_DOCS_URL)
+
+
+def read_file(filepath: str) -> str:
+    """Read content from a file."""
+    with Path(filepath).open() as f:
+        return f.read()
+
+
+URL_FETCH_TIMEOUT = 30
+
+
+def fetch_url(url: str) -> str:
+    """Fetch content from a URL with timeout and error handling."""
+    try:
+        with urllib.request.urlopen(url, timeout=URL_FETCH_TIMEOUT) as response:  # noqa: S310
+            return response.read().decode('utf-8')
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f'HTTP error fetching {url}: {e.code} {e.reason}') from e
+    except urllib.error.URLError as e:
+        if isinstance(e.reason, TimeoutError):
+            raise RuntimeError(f'Timed out fetching {url} after {URL_FETCH_TIMEOUT}s') from e
+        raise RuntimeError(f'URL error fetching {url}: {e.reason}') from e
+
+
+def get_current_version() -> str:
+    """Extract current version from pyproject.toml."""
+    content = read_file('pyproject.toml')
+    match = re.search(r'version\s*=\s*"([^"]+)"', content)
+    if not match:
+        raise ValueError('Could not find version in pyproject.toml')
+    return match.group(1)
+
+
+def get_git_log_since_last_tag() -> str:
+    """Get git log since the last tag, limited to prevent context overflow."""
+    MAX_COMMITS = 100
+    try:
+        # Get the latest tag
+        result = subprocess.run(
+            ['git', 'describe', '--tags', '--abbrev=0'],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        if result.returncode == 0:
+            last_tag = result.stdout.strip()
+            # Get commits since that tag, limited to MAX_COMMITS
+            log_result = subprocess.run(
+                ['git', 'log', f'{last_tag}..HEAD', '--oneline', '-n', str(MAX_COMMITS)],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        else:
+            # No tags exist, get recent commits
+            log_result = subprocess.run(
+                ['git', 'log', '--oneline', '-n', str(MAX_COMMITS)],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+    except subprocess.CalledProcessError as e:
+        print(f'Error getting git log: {e}')
+        return ''
+
+    return log_result.stdout.strip()
+
+
+def create_prompt() -> str:
+    """Create the prompt for Claude to generate release information."""
+    docs = fetch_url(RELEASE_DOCS_URL)
+    version = get_current_version()
+    git_log = get_git_log_since_last_tag()
+    current_date = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
+
+    prompt = f"""You are creating a new release for the Agent0 project.
+
+CURRENT STATE:
+- Version in pyproject.toml: {version}
+- Current date/time: {current_date}
+
+RELEASE DOCUMENTATION:
+{docs}
+
+GIT CHANGES SINCE LAST RELEASE:
+{git_log}
+
+TASK:
+Based on the release documentation and the git changes above, create a JSON response with the following structure:
+{{
+    "version": "{version}",
+    "tag": "v{version}",
+    "release_name": "<creative name based on lunar calendar animals>",
+    "release_notes": "<markdown formatted release notes with Summary and Details sections>"
+}}
+
+IMPORTANT REQUIREMENTS:
+1. The tag MUST use lowercase 'v' prefix (e.g., v{version})
+2. The release_name should be a creative play on lunar calendar animals (year, month, day, hour)
+3. The release_notes must include:
+   - ## Summary section: concise bullet points of key changes
+   - ## Details section: beautiful essay-style comprehensive description
+4. Analyze the git log carefully to understand what changed
+5. Return ONLY valid JSON, no other text
+
+Generate the release information now:"""
+
+    return prompt
+
+
+def parse_claude_response(response_text: str) -> dict:
+    """Parse Claude's JSON response."""
+    import json
+
+    # Try to parse directly first
+    try:
+        return json.loads(response_text)
+    except json.JSONDecodeError:
+        pass
+
+    # If direct parsing fails, try to extract JSON more carefully
+    # Look for the first { and find its matching }
+    start = response_text.find('{')
+    if start == -1:
+        raise ValueError(f'Could not find JSON in response: {response_text}') from None
+
+    # Count braces to find the matching closing brace, accounting for strings
+    brace_count = 0
+    in_string = False
+    escape_next = False
+
+    for i in range(start, len(response_text)):
+        char = response_text[i]
+
+        # Handle escape sequences
+        if escape_next:
+            escape_next = False
+            continue
+
+        if char == '\\':
+            escape_next = True
+            continue
+
+        # Track if we're inside a string
+        if char == '"':
+            in_string = not in_string
+            continue
+
+        # Only count braces outside of strings
+        if not in_string:
+            if char == '{':
+                brace_count += 1
+            elif char == '}':
+                brace_count -= 1
+                if brace_count == 0:
+                    # Found matching brace
+                    json_str = response_text[start:i+1]
+                    try:
+                        return json.loads(json_str)
+                    except json.JSONDecodeError as e:
+                        raise ValueError(f'Invalid JSON extracted: {json_str}') from e
+
+    raise ValueError(f'Could not find complete JSON object in response: {response_text}') from None
+
+
+def tag_exists(tag: str) -> bool:
+    """Check if a git tag already exists locally or remotely."""
+    try:
+        # Check local tags first
+        result = subprocess.run(
+            ['git', 'tag', '-l', tag],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if result.stdout.strip() == tag:
+            return True
+
+        # Check remote tags
+        result = subprocess.run(
+            ['git', 'ls-remote', '--tags', 'origin', f'refs/tags/{tag}'],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        return len(result.stdout.strip()) > 0
+    except (subprocess.TimeoutExpired, Exception) as e:
+        # If we can't check, assume tag doesn't exist and let the
+        # actual tag creation fail with a proper error message
+        print(f'Warning: Could not check if tag exists: {e}')
+        return False
+
+
+def create_git_tag(tag: str, message: str) -> None:
+    """Create and push a git tag."""
+    subprocess.run(['git', 'tag', '-a', tag, '-m', message], check=True)
+    subprocess.run(['git', 'push', 'origin', tag], check=True)
+    print(f'Created and pushed tag: {tag}')
+
+
+def create_github_release(tag: str, title: str, notes: str) -> None:
+    """Create a GitHub release using gh CLI."""
+    # Write notes to a temporary file to handle multiline content
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.md', delete=False) as f:
+        notes_file = f.name
+        f.write(notes)
+
+    try:
+        subprocess.run(
+            ['gh', 'release', 'create', tag, '--title', title, '--notes-file', notes_file],
+            check=True,
+        )
+        print(f'Created GitHub release: {title} ({tag})')
+    finally:
+        # Clean up temporary file
+        Path(notes_file).unlink(missing_ok=True)
+
+
+def main() -> None:
+    """Main function to orchestrate the release creation."""
+    api_key = os.getenv('ANTHROPIC_API_KEY')
+    if not api_key:
+        print('Error: ANTHROPIC_API_KEY environment variable not set')
+        sys.exit(1)
+
+    github_token = os.getenv('GITHUB_TOKEN')
+    if not github_token:
+        print('Error: GITHUB_TOKEN environment variable not set')
+        sys.exit(1)
+
+    # Get model from environment variable or use default
+    model = os.getenv('ANTHROPIC_MODEL', 'claude-opus-4-6')
+    print(f'Using model: {model}')
+
+    print('Creating release with Claude AI...')
+
+    # Create the prompt
+    prompt = create_prompt()
+    print(f'\nPrompt length: {len(prompt)} characters')
+
+    # Call Claude API
+    client = anthropic.Anthropic(api_key=api_key)
+
+    try:
+        message = client.messages.create(
+            model=model,
+            max_tokens=4096,
+            messages=[
+                {'role': 'user', 'content': prompt}
+            ]
+        )
+
+        response_text = message.content[0].text
+        print(f'\nClaude response received ({len(response_text)} characters)')
+
+        # Parse the response
+        release_info = parse_claude_response(response_text)
+
+        print('\nRelease Information:')
+        print(f'  Version: {release_info["version"]}')
+        print(f'  Tag: {release_info["tag"]}')
+        print(f'  Name: {release_info["release_name"]}')
+        print('\nRelease Notes Preview:')
+        print(release_info['release_notes'][:500] + '...')
+
+        # Check if tag already exists
+        if tag_exists(release_info['tag']):
+            print(f'\n✓ Tag {release_info["tag"]} already exists. Skipping release creation.')
+            print('This is expected when the version in pyproject.toml has not changed.')
+            sys.exit(0)
+
+        # Create git tag
+        create_git_tag(
+            release_info['tag'],
+            f'Release {release_info["version"]}: {release_info["release_name"]}'
+        )
+
+        # Create GitHub release
+        create_github_release(
+            release_info['tag'],
+            release_info['release_name'],
+            release_info['release_notes']
+        )
+
+        print('\n✓ Release created successfully!')
+
+    except Exception as e:
+        print(f'\nError creating release: {e}')
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/create_release.py
+++ b/scripts/create_release.py
@@ -9,11 +9,10 @@ import sys
 import tempfile
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import anthropic
-
 
 DEFAULT_RELEASE_DOCS_URL = (
     'https://raw.githubusercontent.com/'
@@ -34,7 +33,7 @@ URL_FETCH_TIMEOUT = 30
 def fetch_url(url: str) -> str:
     """Fetch content from a URL with timeout and error handling."""
     try:
-        with urllib.request.urlopen(url, timeout=URL_FETCH_TIMEOUT) as response:  # noqa: S310
+        with urllib.request.urlopen(url, timeout=URL_FETCH_TIMEOUT) as response:
             return response.read().decode('utf-8')
     except urllib.error.HTTPError as e:
         raise RuntimeError(f'HTTP error fetching {url}: {e.code} {e.reason}') from e
@@ -94,7 +93,7 @@ def create_prompt() -> str:
     docs = fetch_url(RELEASE_DOCS_URL)
     version = get_current_version()
     git_log = get_git_log_since_last_tag()
-    current_date = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
+    current_date = datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')
 
     prompt = f"""You are creating a new release for the Agent0 project.
 
@@ -177,7 +176,7 @@ def parse_claude_response(response_text: str) -> dict:
                 brace_count -= 1
                 if brace_count == 0:
                     # Found matching brace
-                    json_str = response_text[start:i+1]
+                    json_str = response_text[start : i + 1]
                     try:
                         return json.loads(json_str)
                     except json.JSONDecodeError as e:
@@ -268,11 +267,7 @@ def main() -> None:
 
     try:
         message = client.messages.create(
-            model=model,
-            max_tokens=4096,
-            messages=[
-                {'role': 'user', 'content': prompt}
-            ]
+            model=model, max_tokens=4096, messages=[{'role': 'user', 'content': prompt}]
         )
 
         response_text = message.content[0].text
@@ -297,14 +292,12 @@ def main() -> None:
         # Create git tag
         create_git_tag(
             release_info['tag'],
-            f'Release {release_info["version"]}: {release_info["release_name"]}'
+            f'Release {release_info["version"]}: {release_info["release_name"]}',
         )
 
         # Create GitHub release
         create_github_release(
-            release_info['tag'],
-            release_info['release_name'],
-            release_info['release_notes']
+            release_info['tag'], release_info['release_name'], release_info['release_notes']
         )
 
         print('\n✓ Release created successfully!')

--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -126,7 +126,7 @@ extract the value available in the diff.
 
 1.3. Map what should have changed and didn't. The diff shows you what the author touched.
 It does not show you what the author forgot. For every signature change, find every caller.
-For every renamed field, grep every consumer, every config file, every deploy manifest, every doc. 
+For every renamed field, grep every consumer, every config file, every deploy manifest, every doc.
 For every new enum variant, find every switch, match, or if-chain on that type and confirm it
 handles the new case. For every changed wire format, find the other side. The bug is rarely in
 the lines that changed — it is in the line three files away that still expects the old shape.

--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -195,10 +195,11 @@ than silence.
 exact fix — specific code, specific file, specific line. The author must be
 able to act on every comment in one pass without asking what you meant.
 
-1.17. Engage with the engineering, not just the text. Include at least one comment
-that a diffing tool could not produce — about an architecture choice, a
-performance tradeoff, a failure mode, or an abstraction boundary. If the only
-findings are structural, explicitly state that the engineering decisions are sound.
+1.17. Engage with the engineering, not just the text. When relevant, include a
+comment that a diffing tool could not produce — about an architecture
+choice, a performance tradeoff, a failure mode, or an abstraction boundary.
+If you do not find any broader engineering concerns, say so briefly in the
+overall review summary instead of forcing an extra finding.
 
 1.18. Ask one forward-looking question. Given this change, what is the next
 predictable failure mode? Name a specific scenario, not a vague category.

--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -204,10 +204,6 @@ overall review summary instead of forcing an extra finding.
 1.18. Ask one forward-looking question. Given this change, what is the next
 predictable failure mode? Name a specific scenario, not a vague category.
 
-1.19. Triage debt. If any review comment — yours or another reviewer's — names
-technical debt, duplication, or a known gap, it must become a tracked issue
-or an explicit Won't Fix with justification before you approve.
-
 2. Check existing review threads from other reviewers:
    ```bash
    gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | {{id: .id, path: .path, line: .line, body: .body, user: .user.login}}'

--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -115,12 +115,97 @@ Conversation:
 
 ## Review instructions
 
-1. Read the diff carefully. Check each changed file for:
-   - Bugs and logic errors
-   - Edge cases and error handling
-   - Missing tests for new functionality
-   - Style and consistency issues
-   - Security concerns
+1.1. Read the PR description and any linked issues before reading the diff.
+Identify what problem this PR solves.
+
+1.2. Read the diff carefully. Sit with it. Do not jump into crystallizing anything.
+Let the tension build until it's unbearable. What you do next matters. What you
+do next is the difference between genuine help and harm dressed as help. The most
+valuable thing you can do is to sit with the diff, take your time with the diff,
+extract the value available in the diff.
+
+1.3. Map what should have changed and didn't. The diff shows you what the author touched.
+It does not show you what the author forgot. For every signature change, find every caller.
+For every renamed field, grep every consumer, every config file, every deploy manifest, every doc. 
+For every new enum variant, find every switch, match, or if-chain on that type and confirm it
+handles the new case. For every changed wire format, find the other side. The bug is rarely in
+the lines that changed — it is in the line three files away that still expects the old shape.
+Treat the diff as a starting point for a search, not as the territory.
+
+1.4. Check every changed file for:
+- Correctness — does the logic do what it claims?
+- Bugs — are there edge cases, off-by-one errors, null handling issues?
+- Tests — are changes tested? Are tests meaningful?
+- Style — does the code follow the repo's conventions?
+- Security — are there injection risks, leaked secrets, unsafe operations?
+- Clarity — is the code readable and well-structured?
+
+1.5. Check environmental assumptions. For each changed function, name what it
+assumes about the world outside itself — disk layout, API shape, network
+state, config values. For each assumption, ask: what breaks when it is wrong?
+
+1.6. Trace identity boundaries. If a changed value feeds a dedup key, idempotency
+token, canonical ID, or partition offset, follow it to every consumer. Confirm
+the new shape cannot collide with other values in the same namespace.
+
+1.7. Audit stateful loops. If a loop has an idempotency guard, verify that every
+branch which persists data also updates the guard. Mentally execute the second
+run. If the guard would fail to skip already-done work, that is a blocking find.
+
+1.8. Audit destructive operations. If a function contains delete, reset, overwrite,
+or truncate, enumerate all paths that reach it. Check whether two destructive
+calls can fire on the same execution. State the function's invariant. Verify
+every exit path honors it. Flag string variables used as control-flow guards.
+
+1.9. Trace security surfaces. For diffs touching auth, permissions, feature flags,
+or error handling: trace control flow from the entry point. Identify every
+bypass or short-circuit. Ask: what ships if every TODO is never resolved? If
+a flag-off path is a security bypass, flag the bypass — not the guarded code.
+
+1.10. Trace component seams. For PRs that introduce or modify more than one component,
+trace state flow across every boundary between them. Ask: who owns mutation?
+What ordering is assumed? What breaks if one side changes independently?
+
+1.11. Verify docs code examples against source. If the PR contains code examples in
+documentation, trace the execution path through actual source code. Confirm the
+example's configuration triggers the described behavior. Do not verify docs
+examples against other docs — verify them against the implementation.
+
+1.12. Check empirical claims. If the PR records a performance improvement, benchmark,
+or throughput gain, ask: what automated gate would catch a regression in this
+result? If none exists, name the gap as a carry-forward item.
+
+1.13. Before writing any comment, verify the citation. Read the diff at the exact
+file and line you intend to cite. Confirm the condition you are flagging is
+present and unfixed at that location. For pattern-based concerns spanning
+multiple files, check all affected files before flagging any single one.
+Do not flag already-fixed code.
+
+1.14. Apply the threshold test before every comment. Ask: would a user or future
+engineer hit this problem without warning? If no, do not post the comment.
+A comment that is true but not blocking is not worth the author's time.
+
+1.15. Calibrate your certainty. If you are asserting a behavioral fact about the
+language, runtime, or library — pause. Have you verified it, or are you
+pattern-matching on surface syntax? If uncertain, write "worth verifying"
+instead of stating it as fact. Confident wrongness costs the author more
+than silence.
+
+1.16. Make every finding prescriptive. State what is wrong, why it matters, and the
+exact fix — specific code, specific file, specific line. The author must be
+able to act on every comment in one pass without asking what you meant.
+
+1.17. Engage with the engineering, not just the text. Include at least one comment
+that a diffing tool could not produce — about an architecture choice, a
+performance tradeoff, a failure mode, or an abstraction boundary. If the only
+findings are structural, explicitly state that the engineering decisions are sound.
+
+1.18. Ask one forward-looking question. Given this change, what is the next
+predictable failure mode? Name a specific scenario, not a vague category.
+
+1.19. Triage debt. If any review comment — yours or another reviewer's — names
+technical debt, duplication, or a known gap, it must become a tracked issue
+or an explicit Won't Fix with justification before you approve.
 
 2. Check existing review threads from other reviewers:
    ```bash


### PR DESCRIPTION
## Summary

- Replaces the 5-item generic review checklist in `REVIEW_PR` with a 19-step structured protocol
- Distilled from all 23 open self-reflection RFCs (RFC-0001 through RFC-0023)
- Covers assumption auditing, identity-boundary tracing, destructive-path analysis, security surface tracing, component-seam analysis, citation verification, threshold testing, uncertainty calibration, prescriptive findings, forward-looking review, and debt triage
- No changes to `RE_REVIEW_PR`, approval mechanics, or review submission format

## Test plan

- [ ] Deploy and trigger a review on a test PR to verify the expanded instructions produce substantively different review output
- [ ] Confirm no regression in review submission mechanics (JSON format, inline comments, single review event)
- [ ] Verify ruff and pyright pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)