### PR TITLE
feat(prompts): open-threads ledger + red-check-is-a-finding gate before any review verdict (RFC-0070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.4] - 2026-06-06
+
+### Changed
+- `REVIEW_PR` prompt now requires an open-threads ledger before any verdict: the reviewer must take an explicit position (agree / disagree-with-reason / defer-with-reason) on every other-reviewer objection and every CI check, and treat a red check as a finding rather than approving over it (RFC-0070, #107)
+
 ## [0.1.3] - 2026-03-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent0"
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.12"
 dependencies = [
     "httpx==0.28.1",

--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -214,9 +214,23 @@ predictable failure mode? Name a specific scenario, not a vague category.
      ```bash
      gh api repos/{owner}/{repo}/pulls/{number}/comments/COMMENT_ID/replies --method POST -f body="+1 — [your additional context]"
      ```
-   - If it is a new finding, include it as an inline comment in your review (see step 4).
+   - If it is a new finding, include it as an inline comment in your review (see step 5).
 
-4. Submit your review as a SINGLE review event with all inline comments.
+4. Before you submit, clear the open-threads ledger. List every unresolved item your
+   verdict must answer to: every objection in another reviewer's thread (from step 2),
+   and every CI/status check on the PR. Take an explicit position on each — agree,
+   disagree (with a reason), or defer (with a reason). Do not reach a verdict while any
+   entry is silently unaddressed; routing around another reviewer's objection without
+   stating where you land is the failure this prevents.
+   Treat check status as a finding, not a footnote. Fetch the checks:
+   ```bash
+   gh pr checks {number}
+   ```
+   A failing or errored check is itself a finding: flaky-with-a-named-reason, or blocking.
+   "Mostly green" is not a disposition. If a required check is red and you cannot name why
+   it is safe to ignore, do not approve.
+
+5. Submit your review as a SINGLE review event with all inline comments.
    Build a JSON file with your findings, then submit:
    ```bash
    cat > /tmp/review.json << 'REVIEW_EOF'


### PR DESCRIPTION
## What

Adds a pre-verdict gate to `REVIEW_PR` in `src/agent0/prompts.py`. Before submitting any review, the reviewer must build and clear an **open-threads ledger**:

- Enumerate every unresolved item the verdict must answer to — each objection in another reviewer's thread, and each CI/status check on the PR.
- Take an explicit position on each: **agree**, **disagree (with a reason)**, or **defer (with a reason)**. No silent routing-around.
- Treat a failing check as a finding (`gh pr checks {number}`): flaky-with-a-named-reason, or blocking. "Mostly green" is not a disposition — don't approve over a red required check you can't explain.

Inserted as step 4; the submit step is renumbered to 5 and the step-3 cross-reference updated to match.

## Why

This closes the "go quiet at the contested seam" failure named in the PR #79 reflection. The prior prompt told the reviewer to *check* other reviewers' threads but never to take a position on each before the verdict, and **CI/check status appeared nowhere in the review-verdict path at all** — a reviewer could APPROVE with a red required check and never look. Both gaps let a verdict route silently around the unresolved thing.

## Implements

RFC-0070 (#107). Per that RFC's own anti-metric — and this repo's loudest lesson (RFC-0044 "Fifty RFCs Zero Implementations") — the deliverable is this PR, not just the issue.

## Scope / safety

- String-only change to one prompt template. No code paths, schemas, or callers change.
- `ruff check` and `ruff format --check` pass clean. Template verified to render with balanced braces and all placeholders intact (`gh pr checks {number}` resolves; step numbering and cross-reference consistent).
- `RE_REVIEW_PR` is intentionally out of scope (RFC-0069 owns it); can extend there as a follow-up if it proves out here.
- CHANGELOG.md updated; version bumped `0.1.3 → 0.1.4`.
- Trivially revertable in one commit if reviews regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
