### PR TITLE
fix(workspace): recover from unmerged index before checkout

### DIFF
--- a/docs/Error-Codes.md
+++ b/docs/Error-Codes.md
@@ -41,6 +41,7 @@ All codes follow the pattern `E<category><number>`:
 | E3003 | Git checkout failed | Branch doesn't exist or workspace is corrupted |
 | E3004 | Git reset failed | Workspace is in a bad state |
 | E3005 | Git clean failed | Permission issue on workspace files |
+| E3006 | Git reset (recovery) failed | Non-fatal warning. A recovery `git reset --hard` runs before checkout to clear a conflicted/unmerged index left by a prior task (e.g. a half-finished merge/rebase/cherry-pick), so the workspace cannot stay wedged on `error: you need to resolve your current index first`. If this recovery itself fails, the subsequent checkout still surfaces the problem loudly as E3003. |
 
 ### E4xxx — Executor / Claude Code
 

--- a/src/agent0/workspace.py
+++ b/src/agent0/workspace.py
@@ -105,7 +105,7 @@ class WorkspaceManager:
             log.info('Cloning %s/%s', owner, repo)
             workspace.parent.mkdir(parents=True, exist_ok=True)
 
-            returncode, _stdout, stderr = await self._run_git(
+            returncode, _, stderr = await self._run_git(
                 ['clone', self._clone_url(owner, repo), str(workspace)],
             )
             if returncode != 0:
@@ -130,6 +130,22 @@ class WorkspaceManager:
                 default_branch = 'origin/main'
 
             branch = default_branch.removeprefix('origin/')
+
+            # Recover from any half-finished merge/rebase/cherry-pick a prior
+            # task left behind. An unmerged index makes the checkout below refuse
+            # with "you need to resolve your current index first". Resetting hard
+            # to the current HEAD clears the conflicted index (and MERGE_HEAD /
+            # CHERRY_PICK_HEAD / REVERT_HEAD) so the checkout can proceed. This is
+            # local-only: it discards uncommitted state in this clone alone and
+            # never touches the remote.
+            returncode, _, stderr = await self._run_git(
+                ['reset', '--hard'],
+                cwd=workspace,
+            )
+            if returncode != 0:
+                log.warning(
+                    'E3006: git reset (recovery) failed for %s/%s: %s', owner, repo, stderr
+                )
 
             returncode, _, stderr = await self._run_git(
                 ['checkout', branch],

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -106,9 +106,10 @@ class TestPrepare:
 
             assert call_args[0] == ['fetch', 'origin']
             assert call_args[1] == ['rev-parse', '--abbrev-ref', 'origin/HEAD']
-            assert call_args[2] == ['checkout', 'main']
-            assert call_args[3] == ['reset', '--hard', 'origin/main']
-            assert call_args[4] == ['clean', '-fd']
+            assert call_args[2] == ['reset', '--hard']
+            assert call_args[3] == ['checkout', 'main']
+            assert call_args[4] == ['reset', '--hard', 'origin/main']
+            assert call_args[5] == ['clean', '-fd']
 
     @pytest.mark.asyncio
     async def test_clone_failure_raises(self, tmp_path: Path) -> None:
@@ -176,7 +177,61 @@ class TestPrepare:
         with patch.object(mgr, '_run_git', side_effect=side_effect):
             await mgr.prepare('myorg', 'myrepo')
 
-        assert call_count == 5
+        assert call_count == 6
+
+    @pytest.mark.asyncio
+    async def test_recovery_reset_precedes_checkout(self, tmp_path: Path) -> None:
+        """
+        Compute that a recovery `git reset --hard` runs before checkout so a
+        conflicted index left by a prior task cannot wedge the workspace.
+
+        Returns:
+            None
+        """
+
+        config = _make_config(tmp_path)
+        mgr = WorkspaceManager(config)
+
+        workspace = tmp_path / 'workspaces' / 'myorg' / 'myrepo'
+        workspace.mkdir(parents=True)
+
+        with patch.object(mgr, '_run_git', new_callable=AsyncMock) as mock_git:
+            mock_git.return_value = (0, 'origin/main', '')
+
+            await mgr.prepare('myorg', 'myrepo')
+
+            call_args = [c[0][0] for c in mock_git.call_args_list]
+            recovery_idx = call_args.index(['reset', '--hard'])
+            checkout_idx = call_args.index(['checkout', 'main'])
+            assert recovery_idx < checkout_idx
+
+    @pytest.mark.asyncio
+    async def test_recovery_reset_failure_is_non_fatal(self, tmp_path: Path) -> None:
+        """
+        Compute that a failing recovery reset does not raise on its own; the
+        loud failure path remains the checkout that follows it.
+
+        Returns:
+            None
+        """
+
+        config = _make_config(tmp_path)
+        mgr = WorkspaceManager(config)
+
+        workspace = tmp_path / 'workspaces' / 'myorg' / 'myrepo'
+        workspace.mkdir(parents=True)
+
+        async def side_effect(args: list[str], **_kwargs: object) -> tuple[int, str, str]:
+            if args[0] == 'rev-parse':
+                return (0, 'origin/main', '')
+            if args == ['reset', '--hard']:
+                return (1, '', 'recovery boom')
+            return (0, '', '')
+
+        with patch.object(mgr, '_run_git', side_effect=side_effect):
+            result = await mgr.prepare('myorg', 'myrepo')
+
+        assert result == workspace
 
 
 class TestCleanupStale:


### PR DESCRIPTION
## Why
Agent0 was wedged on `Vaquum/Limen` (and any repo whose persistent workspace had a half-finished merge/rebase/cherry-pick). `git checkout` refused with `error: you need to resolve your current index first` → `E3003` on **every** task, and the workspace could never self-recover because `reset --hard` ran *after* the failing checkout.

## Fix
One local-only `git reset --hard` before the checkout, to clear the conflicted index.

- Scoped to the repo's own clone (`cwd=workspace`). **Never touches the remote** — no push/force/branch-delete. The only network op in `prepare()` is the pre-existing read-only `fetch`.
- No new data-loss semantics: `prepare()` already resets `--hard origin/<branch>` + `clean -fd` every run by design; this just makes that "start clean" guarantee reachable when the index is conflicted.

## Verification
- `ruff check` ✓, `ruff format` ✓, `pyright` ✓ (0 errors)
- `pytest tests/test_workspace.py` → 13 passed (incl. 2 new regression tests: recovery-precedes-checkout, recovery-failure-non-fatal)

## Deploy
`render.yaml` auto-deploys from `main`. On merge, the next task on a wedged repo self-heals — no manual workspace deletion needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)