### PR TITLE
feat(prompts): Disposition Ledger — a written verdict for every participant's finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.1.4] - 2026-06-08
+
+### Added
+- **Disposition Ledger** for PR reviews (RFC #114): before any verdict, `REVIEW_PR` now requires a written disposition (`addressed` / `confirmed` / `refuted` / `carry-forward`) and a blast-radius grade for every outstanding finding from every participant — human reviewer threads, bot comments, and failing CI checks. No verdict may be submitted while any ledger row is blank; a red CI check is never merged without a written safe-to-merge or blocking disposition.
+- `REVIEW_PR` now enumerates failing CI checks via the `check-runs` API and treats bot comments as first-class participants alongside human reviewers.
+- `RE_REVIEW_PR` extends the per-thread reply loop so bot findings and previously-red checks each receive a written disposition, not only the agent's own prior threads.
+- Contract tests in `tests/test_prompts.py` asserting the ledger, the four dispositions, participant enumeration, and the blank-row verdict gate.
+- Developer doc `docs/Developer/Disposition-Ledger.md` and user doc `docs/Disposition-Ledger.md`.
+
 ## [0.1.3] - 2026-03-11
 
 ### Added

--- a/docs/Developer/Disposition-Ledger.md
+++ b/docs/Developer/Disposition-Ledger.md
@@ -1,0 +1,57 @@
+# Disposition Ledger
+
+**Status:** Stable
+
+**Context:** How Agent0's PR-review prompts force every outstanding finding — from any participant — into an explicit, written verdict before a review is submitted. Intended for engineers maintaining the review prompts in `src/agent0/prompts.py`.
+
+**Outcome:** After reading, you can explain what the Disposition Ledger is, which prompt steps produce and gate it, and how to extend or test it.
+
+## Overview
+
+A PR review used to let a finding's fate track the quality of its *argument* rather than the severity of the *bug*: eloquently-argued catches got fixed, terse or bot findings drifted, and a red CI check could merge without anyone stating why it was safe. The Disposition Ledger makes every finding's fate an explicit, written decision and orders scrutiny by blast radius rather than rhetoric.
+
+The change is entirely in the `REVIEW_PR` and `RE_REVIEW_PR` templates in `src/agent0/prompts.py`. No executor or router logic changes; the ledger is rendered inline in the review body and is produced by the existing prompt-driven review.
+
+## Concepts
+
+- **Participant** — any source of a finding on the PR: a human reviewer thread, a bot comment, or a failing CI check. Each is treated as a first-class participant whose finding deserves a written disposition.
+- **Disposition** — one of four written verdicts a finding can receive:
+  - `addressed` — fixed; cites the resolving commit SHA or `file:line`.
+  - `confirmed` — still a real problem; blocking.
+  - `refuted` — investigated and shown not to be a problem; gives reasoning.
+  - `carry-forward` — real but out of scope; named for a follow-up.
+- **Blast radius** — the breadth of harm if the finding is real and merges (call sites, users, downstream consumers affected), graded `high` / `med` / `low`. The ledger is ordered by this, descending.
+- **Disposition Ledger** — the structured list, emitted in the review body, of every outstanding finding with its disposition and blast-radius grade.
+
+## How It Works
+
+In `REVIEW_PR`:
+
+1. **Gather (step 2).** After reading the diff, the review enumerates outstanding findings from all three participant classes:
+   - Human reviewer threads and bot comments via `gh api repos/{owner}/{repo}/pulls/{number}/comments`.
+   - Failing CI checks via `gh api repos/{owner}/{repo}/commits/{head_ref}/check-runs` (a check-run fetch failure is surfaced loudly, never silently skipped — per the no-silent-failures contract).
+2. **Disposition & grade (step 4).** Each finding is assigned one of the four dispositions with its required justification and a blast-radius grade, then ordered descending.
+3. **Gate (hard rule).** No verdict may be submitted while any ledger row's disposition is blank. A `refuted` or `carry-forward` is valid; a blank is not. Every `addressed` must cite a commit or line; every `refuted` must give reasoning; a red CI check must receive a written safe-to-merge or blocking disposition.
+4. **Render (step 5).** The ledger is emitted in the review body, including on a clean approval (where it states there were no outstanding findings).
+
+In `RE_REVIEW_PR`, the per-thread reply loop is extended so bot threads and previously-red checks each receive a written disposition reply, not only the agent's own prior threads. A previously-red check has no inline thread, so its disposition is stated in the review body. Because `RE_REVIEW_PR` is not passed a `head_ref`, it resolves the head SHA inline via `gh api repos/{owner}/{repo}/pulls/{number} --jq .head.sha` before fetching check-runs.
+
+## Why check-runs are fetched in-prompt
+
+`REVIEW_PR` receives `formatted_comments` (the human and bot conversation) and `head_ref`, but it is **not** passed `check_failures` (that is a `CI_FAILURE`-event input). The ledger therefore fetches check-run status with `gh api` at review time rather than relying on a template placeholder.
+
+## Testing
+
+Contract tests in `tests/test_prompts.py`:
+
+- `test_review_pr_has_disposition_ledger` — the ledger and the four dispositions are present.
+- `test_review_pr_enumerates_all_participants` — human threads, bot comments, and `check-runs` are all enumerated.
+- `test_review_pr_gates_verdict_on_blank_disposition` — a verdict cannot be submitted while any row is blank, and a red check must carry a disposition.
+- `test_re_review_pr_dispositions_all_participants` — the re-review loop covers bots and checks.
+
+## References
+
+- `src/agent0/prompts.py` — `REVIEW_PR` and `RE_REVIEW_PR` templates.
+- `tests/test_prompts.py` — contract tests.
+- `docs/Disposition-Ledger.md` — the user-facing view.
+- Issue #114 (RFC) — the proposal this implements.

--- a/docs/Developer/README.md
+++ b/docs/Developer/README.md
@@ -24,6 +24,7 @@ Agent0 is a daemon that operates as an autonomous software engineer on GitHub. I
 | [Configuration](Configuration.md) | Every environment variable, defaults, production vs development |
 | [Pipeline](Pipeline.md) | Notification lifecycle from GitHub webhook to executed task |
 | [Executor](Executor.md) | Claude Code CLI integration, prompt templates, PTY streaming, output parsing |
+| [Disposition Ledger](Disposition-Ledger.md) | Per-participant written verdicts that gate PR-review submission |
 | [Dashboard](Dashboard.md) | Frontend architecture, API endpoints, real-time streaming |
 | [Modules](Modules.md) | Module-by-module public API reference |
 | [Deployment](Deployment.md) | Docker build, Render configuration, persistent storage |

--- a/docs/Disposition-Ledger.md
+++ b/docs/Disposition-Ledger.md
@@ -1,0 +1,46 @@
+# Disposition Ledger
+
+**Status:** Stable
+
+**Context:** What you will see in the body of an Agent0 PR review. Intended for anyone whose PR Agent0 reviews — authors, reviewers, and observers.
+
+**Outcome:** After reading, you understand the Disposition Ledger that appears in every Agent0 review and can trust what each row claims.
+
+## What It Is
+
+When Agent0 reviews your pull request, the review summary includes a **Disposition Ledger**: a compact list giving every outstanding finding a written verdict. The findings are gathered from *every* source on the PR — human reviewer comments, automated bot comments, and failing CI checks — so none is left wondering whether it registered.
+
+## What You Will See
+
+The ledger appears in the review body, ordered by blast radius (broadest impact first):
+
+```
+Disposition Ledger (ordered by blast radius):
+- [high]  bot: unbounded retry on 5xx — confirmed, blocking. See inline on poller.py:88.
+- [med]   reviewer @x: dedup key collision — addressed in a1b2c3d.
+- [med]   CI: pyright failing on executor.py — confirmed, blocking; type error is real.
+- [low]   reviewer @y: rename suggestion — carry-forward, noted for follow-up.
+```
+
+Each row carries:
+
+- A **blast-radius grade** in brackets — `high`, `med`, or `low` — for how widely the problem would spread if it merged.
+- The **source** of the finding — a reviewer, a bot, or CI.
+- A short description and a **disposition**, one of:
+  - **addressed** — fixed; the row cites the commit or line that resolved it.
+  - **confirmed** — still a real problem and blocking.
+  - **refuted** — looked into and shown not to be a problem, with the reason given.
+  - **carry-forward** — real, but out of scope for this PR; named for a follow-up.
+
+## Why It Matters
+
+- **No source is second-class.** A terse bot comment and a failing check get the same written verdict as the most eloquently-argued human review.
+- **"Addressed" is verifiable.** Because every row is a written decision that cites its evidence, a later reviewer can trust the word "addressed" without re-deriving it.
+- **No red check merges silently.** A failing CI check always receives a written verdict explaining why it is safe to merge — or that it is not.
+
+Agent0 will not submit a review verdict while any finding is left without a disposition. If you see the ledger, every participant's finding has been accounted for.
+
+## References
+
+- `docs/Developer/Disposition-Ledger.md` — how it is implemented.
+- `docs/CI-Failures.md` — how Agent0 handles failing CI checks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent0"
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.12"
 dependencies = [
     "httpx==0.28.1",

--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -204,24 +204,64 @@ overall review summary instead of forcing an extra finding.
 1.18. Ask one forward-looking question. Given this change, what is the next
 predictable failure mode? Name a specific scenario, not a vague category.
 
-2. Check existing review threads from other reviewers:
-   ```bash
-   gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | {{id: .id, path: .path, line: .line, body: .body, user: .user.login}}'
-   ```
+2. Enumerate outstanding findings from EVERY participant. A *participant* is any source of a
+   finding on this PR: a human reviewer thread, a bot comment, or a failing CI check. Each is a
+   participant whose finding deserves a written disposition — no source is second-class.
+   - Human reviewer threads and bot comments:
+     ```bash
+     gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | {{id: .id, path: .path, line: .line, body: .body, user: .user.login}}'
+     ```
+   - Failing CI checks:
+     ```bash
+     gh api repos/{owner}/{repo}/commits/{head_ref}/check-runs --jq '.check_runs[] | select(.conclusion=="failure" or .conclusion=="timed_out" or .conclusion=="action_required" or .conclusion=="cancelled") | {{name: .name, conclusion: .conclusion, details_url: .details_url, summary: .output.summary}}'
+     ```
+     If this fetch errors, surface the error loudly in your review session and do not proceed to
+     a verdict — a check-run fetch failure is a loud failure, never a silently skipped one.
+   Every comment and every red check from this step becomes an "outstanding finding" that MUST
+   receive a row in the Disposition Ledger (step 4).
 
 3. For each issue you find:
    - If another reviewer already has an open thread on the same or similar issue, reply to their comment instead of opening a new thread:
      ```bash
      gh api repos/{owner}/{repo}/pulls/{number}/comments/COMMENT_ID/replies --method POST -f body="+1 — [your additional context]"
      ```
-   - If it is a new finding, include it as an inline comment in your review (see step 4).
+   - If it is a new finding, include it as an inline comment in your review (see step 5).
 
-4. Submit your review as a SINGLE review event with all inline comments.
+4. Build the **Disposition Ledger** and include it in your review body. The ledger makes every
+   finding's fate an explicit, written decision rather than implicit attention following the
+   most eloquent argument.
+   - One row per outstanding finding, drawn from ALL THREE participant classes in step 2
+     (human reviewer threads, bot comments, failing CI checks). A finding you raise yourself
+     also gets a row.
+   - Each row carries exactly one **disposition**:
+     - `addressed` — fixed; cite the resolving commit SHA or file:line.
+     - `confirmed` — still a real problem; blocking.
+     - `refuted` — investigated and shown NOT to be a problem; give the reasoning.
+     - `carry-forward` — real but out of scope; named for a follow-up.
+   - Each row carries a **blast-radius** grade — `high` / `med` / `low` — the breadth of harm if
+     the finding is real and merges: how many call sites, users, or downstream consumers are
+     affected. Order the rows by blast radius, descending.
+   - Render it in the review body in this format:
+     ```
+     Disposition Ledger (ordered by blast radius):
+     - [high]  bot: unbounded retry on 5xx — confirmed, blocking. See inline on poller.py:88.
+     - [med]   reviewer @x: dedup key collision — addressed in a1b2c3d.
+     - [med]   CI: pyright failing on executor.py — confirmed, blocking; type error is real.
+     - [low]   reviewer @y: rename suggestion — carry-forward, noted for follow-up.
+     ```
+   - **HARD RULE: no verdict may be submitted while any ledger row's disposition is blank.** A
+     `refuted` or `carry-forward` is a valid disposition; a blank is not. Every `addressed` MUST
+     cite a commit or line; every `refuted` MUST give reasoning. A red CI check MUST receive a
+     written safe-to-merge or blocking disposition — never wave a red check through silently.
+   - If there are genuinely no outstanding findings from any participant, say so explicitly:
+     `Disposition Ledger: no outstanding findings from any participant.`
+
+5. Submit your review as a SINGLE review event with all inline comments.
    Build a JSON file with your findings, then submit:
    ```bash
    cat > /tmp/review.json << 'REVIEW_EOF'
    {{
-     "body": "Brief overall summary of the review",
+     "body": "Brief overall summary of the review.\n\nDisposition Ledger (ordered by blast radius):\n- [high] ...\n- [med] ...",
      "event": "REQUEST_CHANGES",
      "comments": [
        {{"path": "src/example.py", "line": 42, "body": "Description of the issue"}},
@@ -232,13 +272,22 @@ predictable failure mode? Name a specific scenario, not a vague category.
    gh api repos/{owner}/{repo}/pulls/{number}/reviews --method POST --input /tmp/review.json
    ```
 
-   If the code looks good with no issues:
+   If the code looks good with no issues, still emit the ledger in the approval body (it states
+   the disposition of any participant findings, or that there were none):
    ```bash
-   gh pr review {number} --approve --body "LGTM"
+   gh pr review {number} --approve --body "LGTM
+
+   Disposition Ledger (ordered by blast radius):
+   - [low] CI: all checks green — no outstanding findings.
+   - reviewer @x: nit on naming — refuted, the current name matches repo convention."
    ```
 
 ## Rules
 
+- **HARD RULE: the review body MUST contain a Disposition Ledger** with a non-blank \
+disposition for every outstanding finding from every participant — human reviewer threads, \
+bot comments, and failing CI checks. No verdict may be submitted while any ledger row is blank. \
+A red CI check is never merged without a written safe-to-merge or blocking disposition.
 - **HARD RULE: `REQUEST_CHANGES` requires inline comments.** You may ONLY submit a \
 `REQUEST_CHANGES` review when you have at least one inline comment on a specific file \
 and line. The review body is a summary — it must NEVER be the sole source of a change \
@@ -263,20 +312,36 @@ PR diff:
 Conversation:
 {formatted_comments}
 
-1. Fetch your previous inline comments:
-   ```bash
-   gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login=="{github_user}") | {{id: .id, path: .path, line: .line, body: .body}}'
-   ```
-2. For each of your previous comments, check whether the issue was fixed in the current diff.
-3. If ALL your previous comments are resolved, approve:
+1. Fetch the findings from EVERY participant — not only your own prior threads. Each participant
+   (your threads, other reviewers, bots, and previously-red CI checks) gets a written disposition
+   reply about whether it is now resolved or why it remains.
+   - Your previous inline comments:
+     ```bash
+     gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login=="{github_user}") | {{id: .id, path: .path, line: .line, body: .body}}'
+     ```
+   - Other reviewer and bot comments (bots are participants too — give them the same courtesy):
+     ```bash
+     gh api repos/{owner}/{repo}/pulls/{number}/comments --jq '.[] | select(.user.login!="{github_user}") | {{id: .id, path: .path, line: .line, body: .body, user: .user.login}}'
+     ```
+   - Current CI check status (to confirm previously-red checks are now green or still failing):
+     ```bash
+     gh api repos/{owner}/{repo}/commits/$(gh api repos/{owner}/{repo}/pulls/{number} --jq .head.sha)/check-runs --jq '.check_runs[] | {{name: .name, conclusion: .conclusion, summary: .output.summary}}'
+     ```
+     If this fetch errors, surface it loudly and do not proceed to a verdict.
+2. For each finding above, check whether it was fixed in the current diff and assign a written
+   disposition (`addressed` / `confirmed` / `refuted` / `carry-forward`).
+3. If ALL findings from every participant are resolved (your threads, bot threads, and CI checks
+   all green), approve:
    ```bash
    gh pr review {number} --approve
    ```
    This command must be run exactly as shown. Do not add --body or any other flags.
-4. If some issues remain, reply to those specific threads explaining what is still wrong:
+4. If some findings remain, reply to each unresolved thread — including bot threads — with its
+   disposition explaining what is still wrong:
    ```bash
    gh api repos/{owner}/{repo}/pulls/{number}/comments/COMMENT_ID/replies --method POST -f body="This is still not addressed: ..."
    ```
+   A previously-red check has no inline thread, so state its disposition in the step 5 review body.
 5. After replying to unresolved threads, submit a changes-requested review:
    ```bash
    gh pr review {number} --request-changes --body "Some items from my previous review still need to be addressed. See my replies on the relevant threads."
@@ -286,9 +351,12 @@ Conversation:
 
 - Run `gh pr review` exactly once per execution. Do not run `gh pr review` more than once.
 - You may call `gh api` to reply to multiple unresolved threads before that single `gh pr review` command.
+- Every participant — your threads, other reviewer/bot threads, and previously-red CI checks — must \
+receive a written disposition: a reply on its thread, or (for a check, which has no thread) a line \
+in the changes-requested review body.
 - When approving, run `gh pr review {number} --approve` with no other flags. No --body. No comment.
 - Do not use `gh pr comment` or `gh issue comment`.
-- Do not write any additional summary, commentary, or praise beyond the exact --body text specified in step 5 for changes-requested reviews."""
+- Do not write any additional summary, commentary, or praise beyond the exact --body text specified in step 5 for changes-requested reviews, plus the per-check dispositions that loop-closing requires."""
 
 
 CI_FAILURE = """CI checks have failed on your PR #{number}: "{title}"

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -111,6 +111,68 @@ class TestPromptsModule:
         assert 'requires inline comments' in prompts.REVIEW_PR.lower()
         assert 'COMMENT' in prompts.REVIEW_PR
 
+    def test_review_pr_has_disposition_ledger(self) -> None:
+        """
+        Compute that REVIEW_PR requires a Disposition Ledger with the four dispositions.
+
+        Returns:
+            None
+        """
+
+        text = prompts.REVIEW_PR
+        assert 'Disposition Ledger' in text
+        assert 'blast' in text.lower()
+        for disposition in ('addressed', 'confirmed', 'refuted', 'carry-forward'):
+            assert disposition in text, f'{disposition} disposition missing from REVIEW_PR'
+
+    def test_review_pr_enumerates_all_participants(self) -> None:
+        """
+        Compute that REVIEW_PR enumerates findings from all three participant classes:
+        human reviewer threads, bot comments, and failing CI checks.
+
+        Returns:
+            None
+        """
+
+        text = prompts.REVIEW_PR
+        assert 'participant' in text.lower()
+        # Bot comments are surfaced via the shared comments endpoint.
+        assert 'bot' in text.lower()
+        # Failing CI checks are fetched via the check-runs API.
+        assert 'check-runs' in text
+        assert 'failing CI check' in text or 'failing checks' in text.lower()
+
+    def test_review_pr_gates_verdict_on_blank_disposition(self) -> None:
+        """
+        Compute that REVIEW_PR forbids submitting a verdict while any ledger row is blank.
+
+        This is the contract that makes an unaddressed bot finding or red check unable to
+        produce a clean verdict: silence is structurally impossible.
+
+        Returns:
+            None
+        """
+
+        text = prompts.REVIEW_PR
+        assert 'no verdict may be submitted while any ledger row' in text.lower()
+        # A red CI check must carry a written disposition, never be waved through.
+        assert 'red CI check' in text or 'red check' in text
+
+    def test_re_review_pr_dispositions_all_participants(self) -> None:
+        """
+        Compute that RE_REVIEW_PR extends the reply loop to bots and previously-red checks,
+        not only the agent's own prior threads.
+
+        Returns:
+            None
+        """
+
+        text = prompts.RE_REVIEW_PR
+        assert 'participant' in text.lower()
+        assert 'bot' in text.lower()
+        assert 'check-runs' in text
+        assert 'disposition' in text.lower()
+
     def test_mention_issue_has_gh_issue_comment(self) -> None:
         """
         Compute that mention in issue uses gh issue comment.


### PR DESCRIPTION
## What

Implements the Disposition Ledger from RFC #114. Before any review verdict, Agent0 now emits a ledger giving **every outstanding finding from every participant** an explicit, written disposition and a blast-radius grade. Silence becomes structurally impossible: a terse bot comment and a failing CI check get the same courtesy as the most eloquently-argued human reviewer.

This is a single prompt diff plus tests and docs — no executor/router logic changes.

## Changes

- **`REVIEW_PR`** (`src/agent0/prompts.py`):
  - Step 2 now enumerates findings from all three participant classes — human reviewer threads, bot comments (shared `comments` endpoint), and failing CI checks (`check-runs` API). A check-run fetch failure is surfaced loudly, never silently skipped.
  - New step 4 requires a **Disposition Ledger** in the review body: one row per finding, each with a disposition (`addressed` / `confirmed` / `refuted` / `carry-forward`), a blast-radius grade (`high`/`med`/`low`), and a one-line justification, ordered by blast radius descending.
  - **Hard rule:** no verdict may be submitted while any ledger row is blank. Every `addressed` cites a commit/line; every `refuted` gives reasoning; a red CI check must get a written safe-to-merge or blocking disposition. The clean-approval path emits the ledger too.
- **`RE_REVIEW_PR`**: the per-thread reply loop is extended so bot threads and previously-red checks each receive a written disposition, not only the agent's own prior threads. Resolves the head SHA inline (the template is not passed `head_ref`).
- **Tests** (`tests/test_prompts.py`): four contract tests covering the ledger, the four dispositions, participant enumeration, and the blank-row verdict gate.
- **Docs**: `docs/Developer/Disposition-Ledger.md` (+ README index entry) and `docs/Disposition-Ledger.md`.
- CHANGELOG entry and `pyproject.toml` version bump `0.1.3` → `0.1.4`.

## Design note

`REVIEW_PR` receives `formatted_comments` and `head_ref` but **not** `check_failures` (that is a `CI_FAILURE`-event input). So the ledger fetches check-run status with `gh api` at review time rather than via a template placeholder — keeping `executor.py` untouched as the RFC requires.

## Verification

- `pytest tests/` → 231 passed
- `ruff check` / `ruff format --check` → clean
- `pyright src/agent0/prompts.py` → 0 errors

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
