### PR TITLE
feat(daemon): make assigned-issue handling idempotent and observable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.4] - 2026-06-08
+
+### Changed
+- Hardened the assigned-issue behaviour so it is safe to run more than once, closing the gap with the battle-tested PR-review path (PR review itself is unchanged):
+  - Idempotent: assignments use a deterministic branch `agent0/issue-<n>` and are skipped when an open PR for that issue already exists, so a restart or redelivered notification no longer opens a duplicate PR.
+  - Visible failures: a failed or timed-out assignment now comments on the issue instead of being silently marked read and dropped.
+  - Outcome check: a "successful" assignment that opened no PR and left no comment is flagged on the issue as a likely silent no-op.
+  - Stronger prompt: read surrounding code first, stay in scope, run the test suite and `ruff` before pushing, and always leave a comment describing the outcome.
+
+### Added
+- Error codes `E2005` (assignment outcome comment failed) and `E7005` (assignment idempotency check failed)
+
 ## [0.1.3] - 2026-03-11
 
 ### Added

--- a/docs/Error-Codes.md
+++ b/docs/Error-Codes.md
@@ -31,6 +31,7 @@ All codes follow the pattern `E<category><number>`:
 | E2002 | API request failed | Non-200 response from GitHub API |
 | E2003 | Unexpected API response | Response body doesn't match expected schema |
 | E2004 | Notification mark-read failed | Could not mark a notification thread as read |
+| E2005 | Assignment outcome comment failed | Non-fatal warning. Could not post the visible outcome comment on an assigned issue (on task failure, or on a success that opened no PR and left no comment). The task itself is unaffected. |
 
 ### E3xxx — Workspace / Git
 
@@ -76,3 +77,4 @@ All codes follow the pattern `E<category><number>`:
 | E7002 | CI scan error | Unhandled exception during CI failure scanning |
 | E7003 | Reflection scan error | Unhandled exception during reflection scanning |
 | E7004 | Context fetch failed | Could not fetch PR/issue context for a notification |
+| E7005 | Assignment idempotency check failed | Non-fatal warning. Could not check whether an open `agent0/issue-<n>` PR already exists for an assigned issue; the assignment proceeds (best-effort duplicate guard). |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent0"
-version = "0.1.3"
+version = "0.1.4"
 requires-python = ">=3.12"
 dependencies = [
     "httpx==0.28.1",

--- a/src/agent0/daemon.py
+++ b/src/agent0/daemon.py
@@ -48,6 +48,44 @@ class _RunningTask:
     started_at_utc: str
 
 
+def _comment_login(comment: dict[str, Any]) -> str:
+    """
+    Compute the lowercased author login of a GitHub comment.
+
+    Args:
+        comment (dict[str, Any]): GitHub comment object
+
+    Returns:
+        str: Lowercased login, or empty string if unavailable
+    """
+
+    user = comment.get('user', {})
+    if not isinstance(user, dict):
+        return ''
+    login = user.get('login', '')
+    return login.lower() if isinstance(login, str) else ''
+
+
+def _is_at_or_after(timestamp: str, start: str) -> bool:
+    """
+    Compute whether an ISO 8601 timestamp is at or after a start time.
+
+    Args:
+        timestamp (str): GitHub timestamp, e.g. 2026-06-08T16:58:17Z
+        start (str): Task start timestamp in ISO 8601
+
+    Returns:
+        bool: True if timestamp >= start; False if either cannot be parsed
+    """
+
+    try:
+        ts = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+        st = datetime.fromisoformat(start.replace('Z', '+00:00'))
+    except (ValueError, AttributeError):
+        return False
+    return ts >= st
+
+
 class Scheduler:
     """
     Compute per-repo task scheduling with concurrency control.
@@ -231,6 +269,9 @@ class Scheduler:
                     output = self._output_buffers.get(repo_key, [])
                     await self._audit(context, result, output if output else None)
 
+                if context.event_type == 'assignment' and result is not None:
+                    await self._handle_assignment_outcome(context, result, now)
+
                 if self._poller:
                     try:
                         await self._poller.mark_read(context.notification_id)
@@ -331,6 +372,83 @@ class Scheduler:
                     }
                 )
         return tasks
+
+    async def _handle_assignment_outcome(
+        self,
+        context: TaskContext,
+        result: ExecutorResult,
+        started_at_utc: str,
+    ) -> None:
+        """
+        Compute a visible outcome on the assigned issue. Never raises.
+
+        Unlike a review, which simply goes unposted when it fails, an assignment
+        that fails or silently no-ops leaves the human assignee with nothing. On
+        failure or timeout, comment so the outcome is visible on the issue. On a
+        success that produced neither a pull request nor any comment from the
+        agent, flag the silent no-op so it does not pass unnoticed.
+
+        Args:
+            context (TaskContext): The assignment task context
+            result (ExecutorResult): Execution result
+            started_at_utc (str): UTC ISO timestamp when the task started
+
+        Returns:
+            None
+        """
+
+        if not self._client:
+            return
+
+        try:
+            if result.status in ('failure', 'timeout'):
+                await self._client.create_issue_comment(
+                    context.owner,
+                    context.repo,
+                    context.number,
+                    f'Agent0 could not complete this assignment (status: {result.status}). '
+                    'A maintainer has been notified; the issue has not been resolved.',
+                )
+                return
+
+            if result.status != 'success':
+                return
+
+            head_ref = f'agent0/issue-{context.number}'
+            pulls = await self._client.get_open_pulls_by_head(
+                context.owner, context.repo, head_ref
+            )
+            if pulls:
+                return
+
+            comments = await self._client.get_issue_comments(
+                context.owner, context.repo, context.number
+            )
+            agent = self._config.github_user.lower()
+            agent_commented = any(
+                _comment_login(c) == agent
+                and _is_at_or_after(c.get('created_at', ''), started_at_utc)
+                for c in comments
+            )
+            if agent_commented:
+                return
+
+            await self._client.create_issue_comment(
+                context.owner,
+                context.repo,
+                context.number,
+                'Agent0 finished this assignment but opened no pull request and left no '
+                'comment. This looks like a silent no-op — please re-assign or clarify '
+                'the task.',
+            )
+        except Exception:
+            log.warning(
+                'E2005: Failed to post assignment outcome for %s/%s#%d: %s',
+                context.owner,
+                context.repo,
+                context.number,
+                traceback.format_exc(),
+            )
 
     async def _report(self, error: Agent0Error) -> None:
         """
@@ -510,6 +628,24 @@ class Daemon:
 
                     task = classify(notification, context, self._config)
 
+                    if task.event_type == 'assignment' and await self._assignment_pr_exists(
+                        task.owner, task.repo, task.number
+                    ):
+                        log.info(
+                            'Skipping assignment for %s/%s#%d: PR already open',
+                            task.owner,
+                            task.repo,
+                            task.number,
+                        )
+                        try:
+                            await self._poller.mark_read(notification.get('id', ''))
+                        except Exception:
+                            log.warning(
+                                'E2004: Failed to mark already-handled assignment %s as read',
+                                notification.get('id'),
+                            )
+                        continue
+
                     if self._scheduler.has_task_for(task.owner, task.repo, task.number):
                         log.info(
                             'Skipping duplicate task for %s/%s#%d (already running/queued)',
@@ -563,6 +699,41 @@ class Daemon:
                     log.warning('E7003: Reflection scan error: %s', traceback.format_exc())
 
             await asyncio.sleep(self._config.poll_interval)
+
+    async def _assignment_pr_exists(self, owner: str, repo: str, number: int) -> bool:
+        """
+        Compute whether Agent0 already has an open PR for an assigned issue.
+
+        This is the assignment-path counterpart to the review path's durable
+        has_agent_reviewed check: an assignment redelivered after the PR was
+        already opened (a restart, or a failed mark-read) must not produce a
+        second PR. Relies on the deterministic branch name agent0/issue-<number>
+        instructed by the ASSIGNED_ISSUE prompt.
+
+        Args:
+            owner (str): Repository owner
+            repo (str): Repository name
+            number (int): Issue number
+
+        Returns:
+            bool: True if an open agent0/issue-<number> pull request exists
+        """
+
+        head_ref = f'agent0/issue-{number}'
+        try:
+            pulls = await self._client.get_open_pulls_by_head(owner, repo, head_ref)
+        except Exception:
+            # Best-effort guard: on a check failure, proceed rather than drop the
+            # assignment. The happy-path mark-read still prevents most duplicates.
+            log.warning(
+                'E7005: Failed to check existing PR for %s/%s#%d: %s',
+                owner,
+                repo,
+                number,
+                traceback.format_exc(),
+            )
+            return False
+        return len(pulls) > 0
 
     async def shutdown(self) -> None:
         """

--- a/src/agent0/daemon.py
+++ b/src/agent0/daemon.py
@@ -81,9 +81,9 @@ def _is_at_or_after(timestamp: str, start: str) -> bool:
     try:
         ts = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
         st = datetime.fromisoformat(start.replace('Z', '+00:00'))
-    except (ValueError, AttributeError):
+        return ts >= st
+    except (ValueError, AttributeError, TypeError):
         return False
-    return ts >= st
 
 
 class Scheduler:

--- a/src/agent0/daemon.py
+++ b/src/agent0/daemon.py
@@ -407,7 +407,7 @@ class Scheduler:
                     context.repo,
                     context.number,
                     f'Agent0 could not complete this assignment (status: {result.status}). '
-                    'A maintainer has been notified; the issue has not been resolved.',
+                    'The issue has not been resolved; please re-assign or ask for clarification.',
                 )
                 return
 

--- a/src/agent0/poller.py
+++ b/src/agent0/poller.py
@@ -444,6 +444,60 @@ class GitHubClient:
         data = response.json()
         return data.get('check_suites', [])  # type: ignore[no-any-return]
 
+    async def get_open_pulls_by_head(
+        self,
+        owner: str,
+        repo: str,
+        head_ref: str,
+    ) -> list[dict[str, Any]]:
+        """
+        Compute open pull requests whose source branch matches head_ref.
+
+        Args:
+            owner (str): Repository owner
+            repo (str): Repository name
+            head_ref (str): Source branch name, without the owner prefix
+
+        Returns:
+            list[dict[str, Any]]: Open pull request objects with this head branch
+        """
+
+        response = await self._client.get(
+            f'/repos/{owner}/{repo}/pulls',
+            params={'state': 'open', 'head': f'{owner}:{head_ref}'},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise TypeError('Expected list payload from /pulls')
+        return cast(list[dict[str, Any]], payload)
+
+    async def create_issue_comment(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        body: str,
+    ) -> None:
+        """
+        Compute creation of a comment on an issue or pull request.
+
+        Args:
+            owner (str): Repository owner
+            repo (str): Repository name
+            number (int): Issue or pull request number
+            body (str): Comment body in markdown
+
+        Returns:
+            None
+        """
+
+        response = await self._client.post(
+            f'/repos/{owner}/{repo}/issues/{number}/comments',
+            json={'body': body},
+        )
+        response.raise_for_status()
+
     async def close(self) -> None:
         """
         Compute client shutdown.

--- a/src/agent0/prompts.py
+++ b/src/agent0/prompts.py
@@ -89,15 +89,26 @@ Labels: {labels}
 Conversation:
 {formatted_comments}
 
-Read the issue carefully. If the task is clear, do the work:
-1. Create a branch named agent0/{{short-description}}
-2. Implement the changes
-3. Commit and push
-4. Create a PR referencing this issue (use "Closes #{number}" in the PR body)
-5. Comment on the issue with a summary of what you did
+Read the issue carefully. If it is unclear, or you lack the information to do it \
+correctly, comment on the issue asking for clarification and stop. Do not guess.
 
-If the task is unclear or you need more information, comment on the issue asking for \
-clarification. Do not guess."""
+If the task is clear, do the work:
+1. Read the surrounding code first. Understand the existing structure, patterns, and \
+conventions before changing anything. Stay strictly within the scope of this issue — \
+do not refactor or fix unrelated things.
+2. Create a branch named agent0/issue-{number} — use this exact name so that re-runs \
+do not create duplicate branches or pull requests.
+3. Implement the change, and add or update tests that cover it.
+4. Before pushing, verify locally: run the test suite, and run `ruff check` and \
+`ruff format`, plus any type check the repo uses. Fix every failure. Do not push code \
+that fails these checks.
+5. Update CHANGELOG.md and bump the version in pyproject.toml.
+6. Commit and push.
+7. Open a pull request whose body contains "Closes #{number}".
+8. Comment on the issue with a short summary of what you did and a link to the PR.
+
+Always leave a comment on the issue describing the outcome — whether you opened a PR, \
+asked for clarification, or could not proceed. Never finish silently."""
 
 
 REVIEW_PR = """You have been asked to review PR #{number}: "{title}"

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -3,11 +3,13 @@
 import asyncio
 import time
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock
 
 import pytest
 
 from agent0.config import Config
-from agent0.daemon import Scheduler, _RunningTask
+from agent0.daemon import Daemon, Scheduler, _RunningTask
+from agent0.executor import ExecutorResult
 from agent0.router import TaskContext
 
 
@@ -187,3 +189,161 @@ class TestSchedulerSubmit:
             await task
         except asyncio.CancelledError:
             pass
+
+
+def _make_assignment(owner: str = 'org', repo: str = 'repo', number: int = 5) -> TaskContext:
+    return TaskContext(
+        event_type='assignment',
+        owner=owner,
+        repo=repo,
+        number=number,
+        subject_type='Issue',
+        trigger_user='alice',
+        trigger_text='do the thing',
+        issue_body='body',
+        diff=None,
+        comments=[],
+        labels=[],
+        head_ref=None,
+        base_ref=None,
+        notification_id='n1',
+    )
+
+
+def _make_result(status: str = 'success') -> ExecutorResult:
+    return ExecutorResult(
+        status=status,
+        response=None,
+        error=None,
+        input_tokens=0,
+        output_tokens=0,
+        cost_usd=0.0,
+        num_turns=0,
+        duration_seconds=0.0,
+        raw_output='',
+    )
+
+
+class TestAssignmentPrExists:
+    @pytest.mark.asyncio
+    async def test_true_when_open_pr_exists(self) -> None:
+        daemon = Daemon(_make_config())
+        await daemon._client.close()
+        daemon._client = AsyncMock()
+        daemon._client.get_open_pulls_by_head.return_value = [{'number': 3}]
+
+        assert await daemon._assignment_pr_exists('org', 'repo', 5) is True
+        daemon._client.get_open_pulls_by_head.assert_awaited_once_with(
+            'org', 'repo', 'agent0/issue-5'
+        )
+
+    @pytest.mark.asyncio
+    async def test_false_when_no_pr(self) -> None:
+        daemon = Daemon(_make_config())
+        await daemon._client.close()
+        daemon._client = AsyncMock()
+        daemon._client.get_open_pulls_by_head.return_value = []
+
+        assert await daemon._assignment_pr_exists('org', 'repo', 5) is False
+
+    @pytest.mark.asyncio
+    async def test_false_on_check_error(self) -> None:
+        daemon = Daemon(_make_config())
+        await daemon._client.close()
+        daemon._client = AsyncMock()
+        daemon._client.get_open_pulls_by_head.side_effect = RuntimeError('boom')
+
+        assert await daemon._assignment_pr_exists('org', 'repo', 5) is False
+
+
+class TestHandleAssignmentOutcome:
+    @pytest.mark.asyncio
+    async def test_failure_comments_on_issue(self) -> None:
+        scheduler = Scheduler(_make_config())
+        scheduler._client = AsyncMock()
+
+        await scheduler._handle_assignment_outcome(
+            _make_assignment(number=7), _make_result('failure'), '2026-06-08T00:00:00+00:00'
+        )
+
+        scheduler._client.create_issue_comment.assert_awaited_once()
+        args = scheduler._client.create_issue_comment.await_args[0]
+        assert args[:3] == ('org', 'repo', 7)
+        assert 'failure' in args[3]
+
+    @pytest.mark.asyncio
+    async def test_timeout_comments_on_issue(self) -> None:
+        scheduler = Scheduler(_make_config())
+        scheduler._client = AsyncMock()
+
+        await scheduler._handle_assignment_outcome(
+            _make_assignment(), _make_result('timeout'), '2026-06-08T00:00:00+00:00'
+        )
+
+        scheduler._client.create_issue_comment.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_success_with_pr_stays_silent(self) -> None:
+        scheduler = Scheduler(_make_config())
+        scheduler._client = AsyncMock()
+        scheduler._client.get_open_pulls_by_head.return_value = [{'number': 9}]
+
+        await scheduler._handle_assignment_outcome(
+            _make_assignment(), _make_result('success'), '2026-06-08T00:00:00+00:00'
+        )
+
+        scheduler._client.create_issue_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_success_no_pr_no_comment_flags_noop(self) -> None:
+        scheduler = Scheduler(_make_config())
+        scheduler._client = AsyncMock()
+        scheduler._client.get_open_pulls_by_head.return_value = []
+        scheduler._client.get_issue_comments.return_value = []
+
+        await scheduler._handle_assignment_outcome(
+            _make_assignment(), _make_result('success'), '2026-06-08T00:00:00+00:00'
+        )
+
+        scheduler._client.create_issue_comment.assert_awaited_once()
+        assert 'no-op' in scheduler._client.create_issue_comment.await_args[0][3]
+
+    @pytest.mark.asyncio
+    async def test_success_no_pr_but_agent_commented_stays_silent(self) -> None:
+        scheduler = Scheduler(_make_config())
+        scheduler._client = AsyncMock()
+        scheduler._client.get_open_pulls_by_head.return_value = []
+        scheduler._client.get_issue_comments.return_value = [
+            {'user': {'login': 'test-bot'}, 'created_at': '2026-06-08T01:00:00Z'},
+        ]
+
+        await scheduler._handle_assignment_outcome(
+            _make_assignment(), _make_result('success'), '2026-06-08T00:00:00+00:00'
+        )
+
+        scheduler._client.create_issue_comment.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_success_stale_agent_comment_flags_noop(self) -> None:
+        scheduler = Scheduler(_make_config())
+        scheduler._client = AsyncMock()
+        scheduler._client.get_open_pulls_by_head.return_value = []
+        scheduler._client.get_issue_comments.return_value = [
+            {'user': {'login': 'test-bot'}, 'created_at': '2026-06-07T00:00:00Z'},
+        ]
+
+        await scheduler._handle_assignment_outcome(
+            _make_assignment(), _make_result('success'), '2026-06-08T00:00:00+00:00'
+        )
+
+        scheduler._client.create_issue_comment.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_outcome_never_raises_on_api_error(self) -> None:
+        scheduler = Scheduler(_make_config())
+        scheduler._client = AsyncMock()
+        scheduler._client.create_issue_comment.side_effect = RuntimeError('boom')
+
+        await scheduler._handle_assignment_outcome(
+            _make_assignment(), _make_result('failure'), '2026-06-08T00:00:00+00:00'
+        )

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -159,6 +159,9 @@ class TestBuildPrompt:
         assert 'feature, ui' in prompt
         assert 'Create a branch named agent0/' in prompt
         assert 'Closes #42' in prompt
+        assert 'agent0/issue-42' in prompt
+        assert 'ruff check' in prompt
+        assert 'Never finish silently' in prompt
 
     def test_review_request_prompt(self) -> None:
         """

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -413,3 +413,73 @@ class TestGitHubClient:
 
         result = await client.get_pull_request_diff('owner', 'repo', 1)
         assert result == ''
+
+    @pytest.mark.asyncio
+    async def test_get_open_pulls_by_head_queries_and_returns(self) -> None:
+        """
+        Compute that get_open_pulls_by_head queries the head branch and returns the list.
+
+        Returns:
+            None
+        """
+
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured['url'] = str(request.url)
+            captured['params'] = dict(request.url.params)
+            return httpx.Response(200, json=[{'number': 7}])
+
+        transport = httpx.MockTransport(handler)
+        client = GitHubClient.__new__(GitHubClient)
+        client._client = httpx.AsyncClient(transport=transport, base_url='https://api.github.com')
+
+        result = await client.get_open_pulls_by_head('org', 'repo', 'agent0/issue-42')
+
+        assert result == [{'number': 7}]
+        assert '/repos/org/repo/pulls' in captured['url']
+        assert captured['params']['state'] == 'open'
+        assert captured['params']['head'] == 'org:agent0/issue-42'
+
+    @pytest.mark.asyncio
+    async def test_get_open_pulls_by_head_returns_empty(self) -> None:
+        """
+        Compute that get_open_pulls_by_head returns an empty list when no PR matches.
+
+        Returns:
+            None
+        """
+
+        transport = httpx.MockTransport(lambda request: httpx.Response(200, json=[]))
+        client = GitHubClient.__new__(GitHubClient)
+        client._client = httpx.AsyncClient(transport=transport, base_url='https://api.github.com')
+
+        result = await client.get_open_pulls_by_head('org', 'repo', 'agent0/issue-1')
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_create_issue_comment_posts_body(self) -> None:
+        """
+        Compute that create_issue_comment POSTs the comment body to the issue.
+
+        Returns:
+            None
+        """
+
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured['method'] = request.method
+            captured['url'] = str(request.url)
+            captured['content'] = request.content.decode()
+            return httpx.Response(201, json={'id': 1})
+
+        transport = httpx.MockTransport(handler)
+        client = GitHubClient.__new__(GitHubClient)
+        client._client = httpx.AsyncClient(transport=transport, base_url='https://api.github.com')
+
+        await client.create_issue_comment('org', 'repo', 42, 'the outcome')
+
+        assert captured['method'] == 'POST'
+        assert '/repos/org/repo/issues/42/comments' in captured['url']
+        assert 'the outcome' in captured['content']


### PR DESCRIPTION
## Why
The assigned-issue behaviour assumed exactly-once, fire-and-forget delivery; the PR-review path is hardened against GitHub's at-least-once, stateful delivery and the assignment path was not. Result: assignments could open **duplicate PRs** on restart/redelivery, and a failed assignment was **silently marked read and dropped** on the user's issue.

**PR review is intentionally untouched** — this only changes the assign path.

## What (all four gaps)
1. **Duplicate PRs** → deterministic branch `agent0/issue-<n>` + skip when an open PR for that issue already exists (durable check, the assignment counterpart to review's `has_agent_reviewed`).
2. **Silent drop** → a failed/timed-out assignment now comments on the issue instead of vanishing.
3. **No check it worked** → a "successful" run that opened no PR and left no comment is flagged on the issue as a likely silent no-op (clarification comments are not flagged).
4. **Thin instructions** → `ASSIGNED_ISSUE` prompt now says: read surrounding code first, stay in scope, run the test suite and `ruff` before pushing, always leave a comment.

## Changes
- `prompts.py`: rewritten `ASSIGNED_ISSUE` (deterministic branch, scope, verify-before-push, never finish silently).
- `poller.py`: `GitHubClient.get_open_pulls_by_head` + `create_issue_comment`.
- `daemon.py`: idempotency skip in the poll loop; `_handle_assignment_outcome` in `_execute` (failure comment / no-op flag), gated on `event_type == 'assignment'`.
- New error codes `E2005`, `E7005`; docs, CHANGELOG, version → 0.1.4.

## Verification
- `ruff check` ✓, `ruff format --check` ✓, `pyright` ✓ (0 errors)
- Full suite: **238 passed** (+13 new tests covering idempotency, failure comment, no-op flag, stale-comment edge, never-raises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)