### PR TITLE
fix: disable Agent0 pull-request reviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Removed
+- Disabled `review_requested` routing so Agent0 cannot submit pull-request reviews. Ignored requests are marked read; mention, assignment, author, comment, and CI-failure handling are unchanged.
+
 ## [0.1.5] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 # Value Proposition
 
-Agent0 polls GitHub notifications, classifies actionable events (mentions, assignments, review requests, CI failures), runs Claude Code tasks in isolated workspaces, and posts results back — all without human intervention.
+Agent0 polls GitHub notifications, classifies actionable events (mentions, assignments, and CI failures), runs Claude Code tasks in isolated workspaces, and posts results back — all without human intervention. Pull-request review requests are intentionally ignored.
 
 # Quick Start
 

--- a/docs/Capability.md
+++ b/docs/Capability.md
@@ -28,7 +28,7 @@ GitHub sends a notification whenever there is new activity on a thread where Age
 | `assign` | Agent0 was assigned to an issue | Read the issue, implement, open a PR |
 | `mention` | Someone @mentioned Agent0 | Read the mention and respond |
 | `author` | Activity on something Agent0 authored | Read the new activity and act on it |
-| `review_requested` | Someone requested Agent0's review | Review the PR and submit feedback |
+| `review_requested` | Someone requested Agent0's review | Ignore the request; no review is submitted |
 | `ci_activity` | CI checks completed | If checks failed on Agent0's PR, fix and push |
 
 ## Multi-Round Reviews

--- a/docs/Developer/Modules.md
+++ b/docs/Developer/Modules.md
@@ -115,7 +115,7 @@ Dataclass carrying all context needed for execution.
 
 ### `should_process(notification, config) -> bool`
 
-Returns `True` if the notification reason is actionable (`mention`, `assign`, `review_requested`, `ci_activity`, `author`).
+Returns `True` if the notification reason is actionable (`mention`, `assign`, `ci_activity`, `author`, or `comment`). Review requests are intentionally not actionable.
 
 ### `classify(notification, context, config) -> TaskContext`
 

--- a/docs/Developer/Pipeline.md
+++ b/docs/Developer/Pipeline.md
@@ -30,13 +30,14 @@ GitHub API  →  Poller  →  Router  →  Scheduler  →  Executor  →  GitHub
 
 ## Step 2: Reason Filtering
 
-`router.should_process()` checks the notification `reason` field:
+Before routing, the daemon discards `review_requested` notifications and marks them read.
+`router.should_process()` then checks the remaining notification `reason` values:
 
 | Reason | Passes filter | Meaning |
 |--------|:---:|---------|
 | `mention` | ✓ | Someone @mentioned the agent |
 | `assign` | ✓ | Agent was assigned to an issue |
-| `review_requested` | ✓ | Someone requested the agent's review |
+| `review_requested` | ✗ | Review automation is intentionally disabled |
 | `ci_activity` | ✓ | CI checks completed on a thread the agent participates in |
 | `author` | ✓ | Activity on something the agent authored (e.g., review on agent's PR) |
 | `subscribed` | ✗ | Watching the repo — not actionable |
@@ -78,7 +79,7 @@ When the agent pushes code or leaves comments, GitHub generates notifications fo
 |-------------------|-----------|---------------------|
 | `mention` | `mention` | `_MENTION_ISSUE` or `_MENTION_PR` |
 | `assign` | `assignment` | `_ASSIGNED_ISSUE` |
-| `review_requested` | `review_request` | `_REVIEW_PR` |
+| `review_requested` | — | — (filtered in Step 2) |
 | `ci_activity` | `ci_failure` | `_CI_FAILURE` |
 | `author` | `mention` | `_MENTION_ISSUE` or `_MENTION_PR` |
 | `comment` | `mention` | `_MENTION_ISSUE` or `_MENTION_PR` |

--- a/docs/Developer/README.md
+++ b/docs/Developer/README.md
@@ -11,7 +11,7 @@ Agent0 is a daemon that operates as an autonomous software engineer on GitHub. I
 ## How It Works
 
 1. **Poll** — The daemon polls GitHub's notifications API for activity on whitelisted orgs
-2. **Route** — Each notification is classified into an event type (mention, assignment, review request, CI failure)
+2. **Route** — Each notification is classified into an event type (mention, assignment, or CI failure); review requests are filtered out
 3. **Execute** — Claude Code CLI receives a structured prompt, works in a repo workspace, and interacts with GitHub via `gh`
 4. **Report** — Results are audited to JSONL files and surfaced through the dashboard
 

--- a/docs/Developer/Troubleshooting.md
+++ b/docs/Developer/Troubleshooting.md
@@ -8,13 +8,13 @@
 
 ## Notifications Not Picked Up
 
-**Symptom:** Agent0 is running but not responding to @mentions, assignments, or reviews.
+**Symptom:** Agent0 is running but not responding to @mentions or assignments.
 
 **Check the poll log.** Look for `Poll returned 0 actionable notifications` in the dashboard log. If polls consistently return 0:
 
 1. **Org not whitelisted** — The repo must belong to an org in `WHITELISTED_ORGS`. Check with `docker logs agent0 | grep 'non-whitelisted'`.
 
-2. **Notification reason not actionable** — Only `mention`, `assign`, `review_requested`, `ci_activity`, `author`, and `comment` are processed. Reasons like `subscribed` are silently dropped.
+2. **Notification reason not actionable** — Only `mention`, `assign`, `ci_activity`, `author`, and `comment` are processed. `review_requested`, `subscribed`, and other reasons are intentionally dropped.
 
 3. **Already processed** — The poller deduplicates by `{notification_id: updated_at}`. If the notification's `updated_at` has not changed since last processing, it is skipped. A fresh poll (every 10th cycle) resets the `If-Modified-Since` cache but not the deduplication dict.
 

--- a/spec/actions.md
+++ b/spec/actions.md
@@ -2,16 +2,20 @@
 
 ## 1. Overview
 
-Agent0 performs exactly four types of actions. Each action is triggered by a specific
-GitHub event and follows a defined workflow. The action type is determined by the router
-and shapes the prompt given to the Claude Code executor.
+Agent0 performs three user-triggered actions. Each action follows a defined workflow. The
+action type is determined by the router and shapes the prompt given to the Claude Code
+executor. CI-failure recovery is a separate background lifecycle described in the daemon
+specification.
 
 | # | Trigger | Action |
 |---|---|---|
 | 1 | Assigned to issue (implementation task) | Code the solution, create a PR |
 | 2 | Assigned to issue (spec task) | Write the spec, post it in the issue |
-| 3 | Assigned as reviewer to PR | Review the code, approve or request changes |
-| 4 | @mentioned in issue or PR | Read the context, post a comment |
+| 3 | @mentioned in issue or PR | Read the context, post a comment |
+
+`review_requested` notifications are intentionally discarded by the daemon before routing
+and excluded from the router's actionable reasons. Agent0 does not submit pull-request
+reviews.
 
 ## 2. Action 1: Code and PR
 
@@ -104,11 +108,16 @@ structure:
 The exact format depends on what the issue asks for — Claude Code has judgment to
 structure the response appropriately.
 
-## 4. Action 3: Review PR
+## 4. Disabled Action: Review PR
+
+This action is not reachable from the daemon. The daemon discards `review_requested`
+notifications before context fetching or execution, marks them read, and keeps a second
+guard in the router's actionable-reason filter. The legacy workflow below is retained only
+as an implementation reference.
 
 ### Trigger
 
-- Notification reason: `review_requested`
+- No active trigger (`review_requested` is filtered)
 - Subject type: `PullRequest`
 
 ### Workflow
@@ -143,7 +152,7 @@ structure the response appropriately.
 - Does not push changes to the PR branch (only the PR author does that)
 - Does not dismiss other reviews
 
-## 5. Action 4: Comment on Mention
+## 5. Action 3: Comment on Mention
 
 ### Trigger
 

--- a/spec/architecture.md
+++ b/spec/architecture.md
@@ -11,7 +11,7 @@ commands, making commits, and interacting with GitHub.
 ### Identity
 
 - GitHub user: `zero-bang`
-- Acts under this identity for all GitHub interactions (comments, commits, reviews, PRs)
+- Acts under this identity for GitHub interactions (comments, commits, and PRs)
 
 ### Whitelisted Organizations
 
@@ -75,11 +75,10 @@ Classifies each notification and determines the action type.
 |---|---|
 | Mentioned in issue/PR comment (`@zero-bang ...`) | Parse the text after the mention, execute the request |
 | Assigned to issue | Read the issue, assess what's needed, act on it |
-| Review requested on PR | Check out the PR, review the code, submit review |
-| Assigned to PR | Same as review requested |
+| Review requested on PR | Ignore; PR review automation is disabled |
 
 The router extracts:
-- **Event type**: mention, assignment, review request
+- **Event type**: mention, assignment, or CI failure
 - **Repository**: owner/repo
 - **Reference**: issue number, PR number, or comment URL
 - **Context**: the text/body that triggered the notification
@@ -143,7 +142,7 @@ Records every action with full traceability.
 Each audit entry contains:
 - **Timestamp** (UTC)
 - **Notification ID**
-- **Event type** (mention, assignment, review request)
+- **Event type** (mention, assignment, or CI failure)
 - **Repository** (owner/repo)
 - **Reference** (issue/PR number)
 - **Trigger** (who triggered it, what they said)

--- a/spec/daemon.md
+++ b/spec/daemon.md
@@ -45,6 +45,9 @@ The main loop is a single `asyncio` event loop running in the main thread.
 while running:
     notifications = poller.poll()
     for notification in notifications:
+        if notification.reason == "review_requested":
+            poller.mark_read(notification.id)
+            continue
         if router.should_process(notification):
             task = router.classify(notification)
             scheduler.submit(task)
@@ -55,6 +58,7 @@ while running:
 
 - The loop runs every `POLL_INTERVAL` seconds (default: 30).
 - `poller.poll()` is a synchronous HTTP call (fast, <1 second).
+- `review_requested` notifications are marked read and discarded before routing.
 - `router.classify()` is pure logic, no I/O.
 - `scheduler.submit()` hands the task off for execution — does not block the loop.
 - The loop itself is never blocked by task execution.
@@ -186,7 +190,7 @@ and renders three sections:
 
 **Running tasks** section shows:
 - Repository (owner/repo)
-- Event type (mention, assignment, review request)
+- Event type (mention, assignment, or CI failure)
 - Trigger (who triggered, brief summary)
 - Started at (UTC timestamp)
 - Elapsed time

--- a/spec/github-integration.md
+++ b/spec/github-integration.md
@@ -46,7 +46,7 @@ GET https://api.github.com/notifications
 | Parameter | Value | Purpose |
 |---|---|---|
 | `all` | `false` | Only unread notifications |
-| `participating` | `true` | Only where `zero-bang` is directly involved (mentioned, assigned, review requested) |
+| `participating` | `true` | Only where `zero-bang` is directly involved; review requests returned by GitHub are discarded and marked read before routing |
 
 ### Response Handling
 
@@ -80,8 +80,10 @@ For each notification:
    is determined by fetching the triggering event and checking the actor.
 3. **Dedup check** — if `notification.id` was already processed (tracked in memory),
    skip.
-4. **Route** — pass to the router for classification.
-5. **Mark as read** — `PATCH /notifications/threads/{id}` to mark the notification as
+4. **Review guard** — if the reason is `review_requested`, mark it read and stop; no
+   context is fetched and no task is scheduled.
+5. **Route** — pass all remaining actionable notifications to the router for classification.
+6. **Mark as read** — `PATCH /notifications/threads/{id}` to mark the notification as
    read.
 
 ### Rate Limiting

--- a/src/agent0/daemon.py
+++ b/src/agent0/daemon.py
@@ -548,6 +548,31 @@ class Daemon:
         self._config.audit_dir.mkdir(parents=True, exist_ok=True)
         log.info('Data directories initialized')
 
+    async def _ignore_review_request(self, notification: dict[str, Any]) -> bool:
+        """
+        Discard a review request without allowing it into the execution pipeline.
+
+        Args:
+            notification (dict[str, Any]): GitHub notification object
+
+        Returns:
+            bool: True when the notification was a discarded review request
+        """
+
+        if notification.get('reason', '') != 'review_requested':
+            return False
+
+        notification_id = notification.get('id', '')
+        log.info('Ignoring disabled review request notification %s', notification_id)
+        try:
+            await self._poller.mark_read(notification_id)
+        except Exception:
+            log.warning(
+                'E2004: Failed to mark ignored review request %s as read',
+                notification_id,
+            )
+        return True
+
     async def poll_loop(self) -> None:
         """
         Compute main polling loop that processes notifications.
@@ -569,6 +594,9 @@ class Daemon:
                     log.info('Received %d notification(s)', len(notifications))
 
                 for notification in notifications:
+                    if await self._ignore_review_request(notification):
+                        continue
+
                     if not should_process(notification, self._config):
                         continue
 

--- a/src/agent0/router.py
+++ b/src/agent0/router.py
@@ -12,11 +12,11 @@ log = logging.getLogger(__name__)
 ACTIONABLE_REASONS = {
     'mention',
     'assign',
-    'review_requested',
     'ci_activity',
     'author',
     'comment',
 }
+# `review_requested` is intentionally excluded: Agent0 must not submit PR reviews.
 
 
 @dataclass

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -3,7 +3,7 @@
 import asyncio
 import time
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -189,6 +189,61 @@ class TestSchedulerSubmit:
             await task
         except asyncio.CancelledError:
             pass
+
+
+class TestIgnoreReviewRequest:
+    @pytest.mark.asyncio
+    async def test_mark_read_failure_still_ignores_review_request(self) -> None:
+        daemon = Daemon(_make_config())
+        await daemon._client.close()
+        daemon._poller = AsyncMock()
+        daemon._poller.mark_read.side_effect = RuntimeError('boom')
+
+        ignored = await daemon._ignore_review_request(
+            {'id': 'review-notification', 'reason': 'review_requested'}
+        )
+
+        assert ignored is True
+
+    @pytest.mark.asyncio
+    async def test_poll_loop_discards_review_request_and_routes_mention(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        daemon = Daemon(_make_config())
+        await daemon._client.close()
+        review = {'id': 'review-notification', 'reason': 'review_requested'}
+        mention = {'id': 'mention-notification', 'reason': 'mention'}
+        daemon._poller = AsyncMock()
+        daemon._poller.poll.return_value = [review, mention]
+        daemon._poller.fetch_context.return_value = {
+            'owner': 'testorg',
+            'repo': 'repo',
+            'number': 42,
+            'subject_type': 'Issue',
+            'body': 'Help wanted',
+            'labels': [],
+            'comments': [],
+            'actor': 'alice',
+            'diff': None,
+            'head_ref': None,
+            'base_ref': None,
+        }
+        daemon._scheduler = Mock()
+        daemon._scheduler.has_task_for.return_value = False
+
+        async def stop_after_first_poll(_seconds: float) -> None:
+            daemon._running = False
+
+        monkeypatch.setattr(asyncio, 'sleep', stop_after_first_poll)
+
+        await daemon.poll_loop()
+
+        daemon._poller.mark_read.assert_awaited_once_with('review-notification')
+        daemon._poller.fetch_context.assert_awaited_once_with(mention)
+        daemon._scheduler.submit.assert_called_once()
+        submitted = daemon._scheduler.submit.call_args.args[0]
+        assert submitted.event_type == 'mention'
+        assert submitted.number == 42
 
 
 def _make_assignment(owner: str = 'org', repo: str = 'repo', number: int = 5) -> TaskContext:

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -49,15 +49,15 @@ class TestShouldProcess:
 
         assert should_process({'reason': 'assign'}, _make_config())
 
-    def test_review_requested(self) -> None:
+    def test_review_requested_not_actionable(self) -> None:
         """
-        Compute that review_requested reason is actionable.
+        Compute that review_requested reason is intentionally ignored.
 
         Returns:
             None
         """
 
-        assert should_process({'reason': 'review_requested'}, _make_config())
+        assert not should_process({'reason': 'review_requested'}, _make_config())
 
     def test_ci_activity(self) -> None:
         """


### PR DESCRIPTION
## What changed

- discard `review_requested` notifications before context fetch or scheduling
- mark ignored review requests read, while failing closed if that API call errors
- retain a second router guard that excludes `review_requested`
- preserve mention, assignment, comment, author, and CI-failure handling
- align specifications and operator documentation with the disabled review path

## Why

A legacy zero-bang review path must not execute even if GitHub requests that account as a reviewer. This makes the retired behavior mechanically unreachable without affecting Agent0's other actions.

## Validation

- `uv run pytest -q` — 242 passed
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright` — 0 errors